### PR TITLE
Trim too long usernames

### DIFF
--- a/poradnia/users/models.py
+++ b/poradnia/users/models.py
@@ -47,8 +47,11 @@ class CustomUserManager(UserManager.from_queryset(UserQuerySet)):
         return user
 
     def email_to_unique_username(self, email, limit=10):
+        SUFFIX_LEN = 3  # "-10"
+        max_length = User._meta.get_field('username').max_length - SUFFIX_LEN
         limit_org = limit
         prefix = re.sub(r'[^A-Za-z-]', '_', email)
+        prefix = prefix[:max_length]
         if not User.objects.filter(username=prefix).exists():
             return prefix
         while limit > 0:

--- a/poradnia/users/models.py
+++ b/poradnia/users/models.py
@@ -47,8 +47,8 @@ class CustomUserManager(UserManager.from_queryset(UserQuerySet)):
         return user
 
     def email_to_unique_username(self, email, limit=10):
-        SUFFIX_LEN = 3  # "-10"
-        max_length = User._meta.get_field('username').max_length - SUFFIX_LEN
+        suffix_len = len(str(limit)) + 1
+        max_length = User._meta.get_field('username').max_length - suffix_len
         limit_org = limit
         prefix = re.sub(r'[^A-Za-z-]', '_', email)
         prefix = prefix[:max_length]

--- a/poradnia/users/tests.py
+++ b/poradnia/users/tests.py
@@ -37,7 +37,7 @@ class UserTestCase(TestCase):
     def test_login_email(self):  # Test for regresion #204
         max_length = User._meta.get_field('username').max_length
         email = 'very-long-email-which-make-broken-username@example.com'
-        self.assertLess(len(User.objects.email_to_unique_username(email)), max_length)
+        self.assertLessEqual(len(User.objects.email_to_unique_username(email)), max_length)
 
     def test_has_picture(self):
         self.assertTrue(UserFactory().picture)


### PR DESCRIPTION
Dodałem poprawkę do przycinania nazw użytkownika. Ograniczenie do 27 (30-3) ze względu na fakt, iż suffix może mieć maksymalnie 3 znaki. Zmieniłem też test na LessEqual.

Klasa User ma metodę .refresh_from_db, która w zasadzie mogłaby być wykorzystana w tej poprawce, ale z jakiegoś powodu w środowisku testowym metoda nie daje efektu (przy normalnym uruchomieniu runserver działa poprawnie). Problem polega na tym, że w metodzie register_email wywołanie self.create_user nie odpytuje bazy danych o faktycznie zapisane dane, więc trzeba ręcznie wywołać odświeżenie.