### PR TITLE
Aktualizacja mixinów logowania

### DIFF
--- a/poradnia/advicer/views.py
+++ b/poradnia/advicer/views.py
@@ -1,16 +1,13 @@
-
 from atom.ext.crispy_forms.views import FormSetMixin
 from atom.views import ActionMessageMixin, ActionView, FormInitialMixin
-from braces.views import (FormValidMessageMixin, LoginRequiredMixin,
-                          SelectRelatedMixin, StaffuserRequiredMixin,
+from braces.views import (FormValidMessageMixin, SelectRelatedMixin,
                           UserFormKwargsMixin)
 from django.core.urlresolvers import reverse_lazy
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import CreateView, DetailView, UpdateView
 from django_filters.views import FilterView
 
-from users.utils import PermissionMixin
-
+from users.utils import PermissionMixin, StaffuserRequiredMixin
 from .filters import AdviceFilter
 from .forms import AdviceForm, AttachmentForm
 from .models import Advice, Attachment
@@ -49,7 +46,7 @@ class AdviceUpdate(StaffuserRequiredMixin, FormSetMixin, PermissionMixin, FormVa
 
 
 class AdviceCreate(StaffuserRequiredMixin, FormSetMixin, FormInitialMixin, UserFormKwargsMixin,
-                   LoginRequiredMixin, CreateView):
+                   CreateView):
     model = Advice
     form_class = AdviceForm
     inline_model = Attachment

--- a/poradnia/cases/views/cases.py
+++ b/poradnia/cases/views/cases.py
@@ -18,7 +18,7 @@ from records.models import Record
 from users.views import PermissionMixin
 
 
-class CaseDetailView(LoginRequiredMixin, TemplateView):  # TODO: Use django.views.generic.DetailView
+class CaseDetailView(LoginRequiredMixin, TemplateView):
     template_name = 'cases/case_detail.html'
 
     def get_context_data(self, **kwargs):

--- a/poradnia/cases/views/cases.py
+++ b/poradnia/cases/views/cases.py
@@ -1,7 +1,8 @@
 from __future__ import absolute_import
 
-from braces.views import LoginRequiredMixin, UserFormKwargsMixin
+from braces.views import UserFormKwargsMixin
 from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.shortcuts import get_object_or_404, redirect
 from django.utils.translation import ugettext as _
 from django.views.generic import TemplateView, UpdateView

--- a/poradnia/events/tests/test_management_commands.py
+++ b/poradnia/events/tests/test_management_commands.py
@@ -1,6 +1,7 @@
 from __future__ import print_function
 
 from datetime import timedelta
+from unittest import TestCase
 
 from django.core import mail, management
 from django.test import TestCase

--- a/poradnia/events/tests/test_reminders.py
+++ b/poradnia/events/tests/test_reminders.py
@@ -69,7 +69,7 @@ class RemindersTestCase(TestCase):
 
         # force trigger
         reminder.triggered = True
-        reminder.save()
+        reminder.save(update_fields=('triggered', ))
         self.assertTrue(reminder.triggered)
 
         # edit event

--- a/poradnia/events/views.py
+++ b/poradnia/events/views.py
@@ -1,7 +1,7 @@
 import locale
 
-from braces.views import (FormValidMessageMixin, LoginRequiredMixin,
-                          SelectRelatedMixin, UserFormKwargsMixin)
+from braces.views import (FormValidMessageMixin, SelectRelatedMixin,
+                          UserFormKwargsMixin)
 from dateutil.relativedelta import relativedelta
 from django.conf import settings
 from django.http import HttpResponse
@@ -16,7 +16,6 @@ from django.views.generic.list import BaseListView
 from cases.models import Case
 from keys.mixins import KeyAuthMixin
 from users.utils import PermissionMixin
-
 from .forms import EventForm
 from .models import Event
 from .utils import EventCalendar
@@ -64,14 +63,14 @@ def dismiss(request, pk):  # TODO
     pass
 
 
-class CalendarListView(PermissionMixin, LoginRequiredMixin, ArchiveIndexView):
+class CalendarListView(PermissionMixin, ArchiveIndexView):
     model = Event
     date_field = 'time'
     allow_future = True
     date_list_period = 'month'
 
 
-class CalendarEventView(PermissionMixin, SelectRelatedMixin, LoginRequiredMixin, MonthArchiveView):
+class CalendarEventView(PermissionMixin, SelectRelatedMixin, MonthArchiveView):
     model = Event
     date_field = "time"
     allow_future = True

--- a/poradnia/notifications_custom/views.py
+++ b/poradnia/notifications_custom/views.py
@@ -1,5 +1,5 @@
-from braces.views import (LoginRequiredMixin, PrefetchRelatedMixin,
-                          SelectRelatedMixin)
+from braces.views import PrefetchRelatedMixin, SelectRelatedMixin
+from django.contrib.auth.mixins import LoginRequiredMixin
 from django.views.generic import TemplateView
 
 

--- a/poradnia/stats/tests.py
+++ b/poradnia/stats/tests.py
@@ -12,7 +12,7 @@ from cases.models import Case
 from letters.factories import LetterFactory
 from letters.models import Letter
 from stats.utils import GapFiller, DATE_FORMAT_MONTHLY, DATE_FORMAT_WEEKLY
-from users.factories import UserFactory
+from users.factories import UserFactory, StaffFactory
 
 
 def polyfill_http_response_json():
@@ -41,6 +41,13 @@ class StatsCaseCreatedPermissionTestCase(TestCase):
             resp = self.client.get(url)
             self.assertEqual(resp.status_code, 302)
 
+    def test_permission_staff(self):
+        user = StaffFactory()
+        self.client.login(username=user.username, password='pass')
+        for url in [self.api_url, self.render_url, self.main_url]:
+            resp = self.client.get(url)
+            self.assertEqual(resp.status_code, 403)
+
     @skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
     def test_permission_superuser(self):
         user = UserFactory(is_superuser=True)
@@ -56,24 +63,30 @@ class StatsCaseUnansweredPermissionTestCase(TestCase):
         self.render_url = reverse('stats:case_unanswered_render')
         self.main_url = reverse('stats:case_unanswered')
 
-    def test_permission_not_logged_in(self):
+    def test_permission_logged_in(self):
         user = UserFactory(is_superuser=False)
         self.client.login(username=user.username, password='pass')
-        for url in[self.api_url, self.render_url, self.main_url]:
+        for url in [self.api_url, self.render_url, self.main_url]:
             resp = self.client.get(url)
             self.assertEqual(resp.status_code, 403)
 
     def test_permission_not_logged_in(self):
-        user = UserFactory(is_superuser=False)
-        for url in[self.api_url, self.render_url, self.main_url]:
+        for url in [self.api_url, self.render_url, self.main_url]:
             resp = self.client.get(url)
             self.assertEqual(resp.status_code, 302)
+
+    def test_permission_staff(self):
+        user = StaffFactory()
+        self.client.login(username=user.username, password='pass')
+        for url in [self.api_url, self.render_url, self.main_url]:
+            resp = self.client.get(url)
+            self.assertEqual(resp.status_code, 403)
 
     @skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
     def test_permission_superuser(self):
         user = UserFactory(is_superuser=True)
         self.client.login(username=user.username, password='pass')
-        for url in[self.api_url, self.render_url, self.main_url]:
+        for url in [self.api_url, self.render_url, self.main_url]:
             resp = self.client.get(url)
             self.assertEqual(resp.status_code, 200)
 
@@ -84,7 +97,7 @@ class StatsCaseReactionPermissionTestCase(TestCase):
         self.render_url = reverse('stats:case_reaction_render')
         self.main_url = reverse('stats:case_reaction')
 
-    def test_permission_not_logged_in(self):
+    def test_permission_logged_in(self):
         user = UserFactory(is_superuser=False)
         self.client.login(username=user.username, password='pass')
         for url in[self.api_url, self.render_url, self.main_url]:
@@ -92,10 +105,16 @@ class StatsCaseReactionPermissionTestCase(TestCase):
             self.assertEqual(resp.status_code, 403)
 
     def test_permission_not_logged_in(self):
-        user = UserFactory(is_superuser=False)
         for url in[self.api_url, self.render_url, self.main_url]:
             resp = self.client.get(url)
             self.assertEqual(resp.status_code, 302)
+
+    def test_permission_staff(self):
+        user = StaffFactory()
+        self.client.login(username=user.username, password='pass')
+        for url in [self.api_url, self.render_url, self.main_url]:
+            resp = self.client.get(url)
+            self.assertEqual(resp.status_code, 403)
 
     def test_permission_superuser(self):
         user = UserFactory(is_superuser=True)

--- a/poradnia/stats/tests.py
+++ b/poradnia/stats/tests.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 from unittest import skipUnless
 
-from dateutil.rrule import MONTHLY, WEEKLY, DAILY
+from dateutil.rrule import MONTHLY, WEEKLY
 from django.core.urlresolvers import reverse
 from django.db import connection
 from django.http.response import HttpResponse
@@ -11,8 +11,8 @@ from cases.factories import CaseFactory
 from cases.models import Case
 from letters.factories import LetterFactory
 from letters.models import Letter
-from users.factories import UserFactory
 from stats.utils import GapFiller, DATE_FORMAT_MONTHLY, DATE_FORMAT_WEEKLY
+from users.factories import UserFactory
 
 
 def polyfill_http_response_json():
@@ -37,7 +37,6 @@ class StatsCaseCreatedPermissionTestCase(TestCase):
             self.assertEqual(resp.status_code, 403)
 
     def test_permission_not_logged_in(self):
-        user = UserFactory(is_superuser=False)
         for url in[self.api_url, self.render_url, self.main_url]:
             resp = self.client.get(url)
             self.assertEqual(resp.status_code, 302)

--- a/poradnia/stats/utils.py
+++ b/poradnia/stats/utils.py
@@ -82,6 +82,7 @@ class GapFiller(object):
                                 freq=self.freq,
                                 dtstart=datetime.strptime(start, date_format),
                                 until=datetime.strptime(end, date_format)))
+
     def _get_params(self):
         if hasattr(self, 'params'):
             return self.params

--- a/poradnia/stats/utils.py
+++ b/poradnia/stats/utils.py
@@ -1,19 +1,43 @@
 from datetime import datetime
 
 from dateutil.rrule import rrule, MONTHLY, WEEKLY
-
-from django.shortcuts import redirect
+from django.contrib.auth.mixins import AccessMixin
+from django.contrib.auth.views import redirect_to_login
+from django.core.exceptions import PermissionDenied
 
 
 SECONDS_IN_A_DAY = 60 * 60 * 24
 DATE_FORMAT_MONTHLY = "%Y-%m"
 DATE_FORMAT_WEEKLY = "%Y-%W"
 
-def raise_unless_unauthenticated(view, request):
-    # Hack from SO due to https://github.com/brack3t/django-braces/issues/181 bug
-    if not request.user.is_authenticated():
-        return redirect('/konta/login/?next=%s' % request.path)
-    return None
+
+class NoPermissionHandlerMixin(AccessMixin):
+    """
+    Mixin borrowed from Braces. If user is authenticated and does not have
+    permissions, it's redirected to 403 page. Anonymous user is redirected to
+    log in page
+    """
+    def handle_no_permission(self):
+        if self.raise_exception:
+            if (self.redirect_unauthenticated_users
+                    and not self.request.user.is_authenticated()):
+                return self.no_permissions_fail()
+            else:
+                raise PermissionDenied
+
+        return self.no_permissions_fail()
+
+    def no_permissions_fail(self):
+        """
+        Called when the user has no permissions and no exception was raised.
+        This should only return a valid HTTP response.
+
+        By default we redirect to login.
+        """
+        return redirect_to_login(self.request.get_full_path(),
+                                 self.get_login_url(),
+                                 self.get_redirect_field_name())
+
 
 class GapFiller(object):
     def __init__(self, qs, freq, date_key, date_format):

--- a/poradnia/stats/views.py
+++ b/poradnia/stats/views.py
@@ -1,15 +1,13 @@
-from datetime import datetime
+from braces.views import JSONResponseMixin
 from dateutil.rrule import MONTHLY
-
-from django.db.models import F, Func, IntegerField, Case, Sum, When, Min, Count
-from django.shortcuts import redirect
-from braces.views import JSONResponseMixin, LoginRequiredMixin, SuperuserRequiredMixin
+from django.db.models import F, IntegerField, Case, Sum, When, Min, Count
 from django.views.generic import TemplateView
 from django.views.generic import View
 
 from cases.models import Case as CaseModel
 from letters.models import Letter as LetterModel
-from .utils import raise_unless_unauthenticated, GapFiller, SECONDS_IN_A_DAY, DATE_FORMAT_MONTHLY
+from users.utils import SuperuserRequiredMixin
+from .utils import GapFiller, SECONDS_IN_A_DAY, DATE_FORMAT_MONTHLY, NoPermissionHandlerMixin
 
 
 class ApiListViewMixin(JSONResponseMixin):
@@ -21,18 +19,24 @@ class StatsIndexView(TemplateView):
     template_name = 'stats/index.html'
 
 
-class StatsCaseCreatedView(LoginRequiredMixin, SuperuserRequiredMixin, TemplateView):
+class StatsCaseCreatedView(NoPermissionHandlerMixin, SuperuserRequiredMixin,
+                           TemplateView):
     template_name = 'stats/cases/created.html'
-    raise_exception = raise_unless_unauthenticated
+    raise_exception = True
+    redirect_unauthenticated_users = True
 
 
-class StatsCaseCreatedRenderView(LoginRequiredMixin, SuperuserRequiredMixin, TemplateView):
+class StatsCaseCreatedRenderView(NoPermissionHandlerMixin,
+                                 SuperuserRequiredMixin, TemplateView):
     template_name = 'stats/render/cases/created.html'
-    raise_exception = raise_unless_unauthenticated
+    raise_exception = True
+    redirect_unauthenticated_users = True
 
 
-class StatsCaseCreatedApiView(LoginRequiredMixin, SuperuserRequiredMixin, ApiListViewMixin, View):
-    raise_exception = raise_unless_unauthenticated
+class StatsCaseCreatedApiView(NoPermissionHandlerMixin, SuperuserRequiredMixin,
+                              ApiListViewMixin, View):
+    raise_exception = True
+    redirect_unauthenticated_users = True
 
     def get_object_list(self):
         qs = CaseModel.objects.with_month_year().values(
@@ -80,18 +84,15 @@ class StatsCaseCreatedApiView(LoginRequiredMixin, SuperuserRequiredMixin, ApiLis
         ).fill_gaps()
 
 
-class StatsCaseReactionView(LoginRequiredMixin, SuperuserRequiredMixin, TemplateView):
+class StatsCaseReactionView(SuperuserRequiredMixin, TemplateView):
     template_name = 'stats/cases/reaction.html'
-    raise_exception = raise_unless_unauthenticated
 
 
-class StatsCaseReactionRenderView(LoginRequiredMixin, SuperuserRequiredMixin, TemplateView):
+class StatsCaseReactionRenderView(SuperuserRequiredMixin, TemplateView):
     template_name = 'stats/render/cases/reaction.html'
-    raise_exception = raise_unless_unauthenticated
 
 
-class StatsCaseReactionApiView(LoginRequiredMixin, SuperuserRequiredMixin, ApiListViewMixin, View):
-    raise_exception = raise_unless_unauthenticated
+class StatsCaseReactionApiView(SuperuserRequiredMixin, ApiListViewMixin, View):
 
     def get_object_list(self):
         qs = (
@@ -133,19 +134,15 @@ class StatsCaseReactionApiView(LoginRequiredMixin, SuperuserRequiredMixin, ApiLi
         ).fill_gaps()
 
 
-class StatsCaseUnansweredView(LoginRequiredMixin, SuperuserRequiredMixin, TemplateView):
+class StatsCaseUnansweredView(SuperuserRequiredMixin, TemplateView):
     template_name = 'stats/cases/unanswered.html'
-    raise_exception = raise_unless_unauthenticated
 
 
-class StatsCaseUnansweredRenderView(LoginRequiredMixin, SuperuserRequiredMixin, TemplateView):
+class StatsCaseUnansweredRenderView(SuperuserRequiredMixin, TemplateView):
     template_name = 'stats/render/cases/unanswered.html'
-    raise_exception = raise_unless_unauthenticated
 
 
-class StatsCaseUnansweredApiView(LoginRequiredMixin, SuperuserRequiredMixin, ApiListViewMixin,
-                                 View):
-    raise_exception = raise_unless_unauthenticated
+class StatsCaseUnansweredApiView(SuperuserRequiredMixin, ApiListViewMixin, View):
 
     def get_object_list(self):
         qs = CaseModel.objects.filter(
@@ -171,18 +168,15 @@ class StatsCaseUnansweredApiView(LoginRequiredMixin, SuperuserRequiredMixin, Api
         ).fill_gaps()
 
 
-class StatsLetterCreatedView(LoginRequiredMixin, SuperuserRequiredMixin, TemplateView):
+class StatsLetterCreatedView(SuperuserRequiredMixin, TemplateView):
     template_name = 'stats/letters/created.html'
-    raise_exception = raise_unless_unauthenticated
 
 
-class StatsLetterCreatedRenderView(LoginRequiredMixin, SuperuserRequiredMixin, TemplateView):
+class StatsLetterCreatedRenderView(SuperuserRequiredMixin, TemplateView):
     template_name = 'stats/render/letters/created.html'
-    raise_exception = raise_unless_unauthenticated
 
 
-class StatsLetterCreatedApiView(LoginRequiredMixin, SuperuserRequiredMixin, ApiListViewMixin, View):
-    raise_exception = raise_unless_unauthenticated
+class StatsLetterCreatedApiView(SuperuserRequiredMixin, ApiListViewMixin, View):
 
     def get_object_list(self):
         qs = LetterModel.objects.with_month_year().values(

--- a/poradnia/stats/views.py
+++ b/poradnia/stats/views.py
@@ -84,15 +84,24 @@ class StatsCaseCreatedApiView(NoPermissionHandlerMixin, SuperuserRequiredMixin,
         ).fill_gaps()
 
 
-class StatsCaseReactionView(SuperuserRequiredMixin, TemplateView):
+class StatsCaseReactionView(NoPermissionHandlerMixin, SuperuserRequiredMixin,
+                            TemplateView):
     template_name = 'stats/cases/reaction.html'
+    raise_exception = True
+    redirect_unauthenticated_users = True
 
 
-class StatsCaseReactionRenderView(SuperuserRequiredMixin, TemplateView):
+class StatsCaseReactionRenderView(NoPermissionHandlerMixin,
+                                  SuperuserRequiredMixin, TemplateView):
     template_name = 'stats/render/cases/reaction.html'
+    raise_exception = True
+    redirect_unauthenticated_users = True
 
 
-class StatsCaseReactionApiView(SuperuserRequiredMixin, ApiListViewMixin, View):
+class StatsCaseReactionApiView(NoPermissionHandlerMixin, SuperuserRequiredMixin,
+                               ApiListViewMixin, View):
+    raise_exception = True
+    redirect_unauthenticated_users = True
 
     def get_object_list(self):
         qs = (
@@ -134,15 +143,24 @@ class StatsCaseReactionApiView(SuperuserRequiredMixin, ApiListViewMixin, View):
         ).fill_gaps()
 
 
-class StatsCaseUnansweredView(SuperuserRequiredMixin, TemplateView):
+class StatsCaseUnansweredView(NoPermissionHandlerMixin, SuperuserRequiredMixin,
+                              TemplateView):
     template_name = 'stats/cases/unanswered.html'
+    raise_exception = True
+    redirect_unauthenticated_users = True
 
 
-class StatsCaseUnansweredRenderView(SuperuserRequiredMixin, TemplateView):
+class StatsCaseUnansweredRenderView(NoPermissionHandlerMixin,
+                                    SuperuserRequiredMixin, TemplateView):
     template_name = 'stats/render/cases/unanswered.html'
+    raise_exception = True
+    redirect_unauthenticated_users = True
 
 
-class StatsCaseUnansweredApiView(SuperuserRequiredMixin, ApiListViewMixin, View):
+class StatsCaseUnansweredApiView(NoPermissionHandlerMixin, SuperuserRequiredMixin,
+                                 ApiListViewMixin, View):
+    raise_exception = True
+    redirect_unauthenticated_users = True
 
     def get_object_list(self):
         qs = CaseModel.objects.filter(

--- a/poradnia/tasty_feedback/views.py
+++ b/poradnia/tasty_feedback/views.py
@@ -1,7 +1,7 @@
-from braces.views import (FormValidMessageMixin, LoginRequiredMixin,
-                          PermissionRequiredMixin, SelectRelatedMixin,
+from braces.views import (FormValidMessageMixin, SelectRelatedMixin,
                           UserFormKwargsMixin)
 from django.contrib import messages
+from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.urlresolvers import reverse_lazy
 from django.http import HttpResponseRedirect
 from django.utils.translation import ugettext as _
@@ -12,7 +12,7 @@ from .models import Feedback
 from .utils import get_filter, get_form
 
 
-class FeedbackListView(LoginRequiredMixin, PermissionRequiredMixin, SelectRelatedMixin, FilterView):
+class FeedbackListView(PermissionRequiredMixin, SelectRelatedMixin, FilterView):
     permission_required = "tasty_feedback.view_feedback"
     filterset_class = get_filter()
     select_related = ["user", ]
@@ -29,12 +29,12 @@ class FeedbackCreateView(UserFormKwargsMixin, FormValidMessageMixin, CreateView)
         return _("Feedback saved.")
 
 
-class FeedbackDetailView(LoginRequiredMixin, PermissionRequiredMixin, DetailView):
+class FeedbackDetailView(PermissionRequiredMixin, DetailView):
     permission_required = "tasty_feedback.view_feedback"
     model = Feedback
 
 
-class FeedbackStatusView(LoginRequiredMixin, PermissionRequiredMixin, DeleteView):
+class FeedbackStatusView(PermissionRequiredMixin, DeleteView):
     permission_required = "tasty_feedback.change_feedback"
     model = Feedback
     template_name_suffix = '_switch_status'

--- a/poradnia/users/utils.py
+++ b/poradnia/users/utils.py
@@ -1,4 +1,4 @@
-from braces.views import LoginRequiredMixin
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
 from django.core.exceptions import PermissionDenied
 from guardian.shortcuts import get_perms
 
@@ -14,6 +14,18 @@ def has_perms(user, perms, obj=None, required_all=True):
     if not required_all and any(tests):
         return True
     raise PermissionDenied
+
+
+class SuperuserRequiredMixin(UserPassesTestMixin):
+
+    def test_func(self):
+        return self.request.user.is_superuser
+
+
+class StaffuserRequiredMixin(UserPassesTestMixin):
+
+    def test_func(self):
+        return self.request.user.is_staff
 
 
 class PermissionMixin(LoginRequiredMixin, object):

--- a/poradnia/users/views.py
+++ b/poradnia/users/views.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
-from braces.views import (LoginRequiredMixin, StaffuserRequiredMixin,
-                          UserFormKwargsMixin)
-from django.contrib.auth.mixins import PermissionRequiredMixin
+from braces.views import UserFormKwargsMixin
+from django.contrib.auth.mixins import (LoginRequiredMixin,
+                                        PermissionRequiredMixin)
 from django.core.urlresolvers import reverse
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import DetailView, RedirectView, UpdateView
@@ -51,7 +51,7 @@ class UserUpdateView(LoginRequiredMixin, UpdateView):
         return User.objects.get(username=self.request.user.username)
 
 
-class ProfileUpdateView(UserFormKwargsMixin, LoginRequiredMixin, UpdateView):
+class ProfileUpdateView(LoginRequiredMixin, UpdateView):
     form_class = ProfileForm
     model = Profile
 

--- a/poradnia/users/views.py
+++ b/poradnia/users/views.py
@@ -10,7 +10,7 @@ from django_filters.views import FilterView
 from .filters import UserFilter
 from .forms import ProfileForm, UserForm
 from .models import Profile, User
-from .utils import PermissionMixin
+from .utils import PermissionMixin, StaffuserRequiredMixin
 
 
 class UserDetailView(PermissionRequiredMixin, DetailView):
@@ -62,6 +62,11 @@ class ProfileUpdateView(LoginRequiredMixin, UpdateView):
     def get_object(self):
         # Only get the User record for the user making the request
         return Profile.objects.get_or_create(user=self.request.user)[0]
+
+    def get_form_kwargs(self):
+        kwargs = super(ProfileUpdateView, self).get_form_kwargs()
+        kwargs.update({'user': self.request.user})
+        return kwargs
 
 
 class UserListView(StaffuserRequiredMixin, PermissionMixin, FilterView):


### PR DESCRIPTION
Zamieniłem mixin `LoginRequiredMixin` z Braces na wersję z Django. Niestety, są małe różnice w działaniu obu bibliotek (`handle_no_permission` w Braces przyjmuje argument `request` natomiast wersja z Django nie, request jest dostępny jako atrybut klasy), musiałem więc przepisać 2 mixiny: `SuperuserRequiredMixin` i  `StaffuserRequiredMixin` oraz dodać `NoPermissionHandlerMixin` który ma z grubsza taką samą funkcjonalność jak metoda `raise_unless_unauthenticated`. 

Wszystkie testy przechodzą ale obawiam się że nie każdy widok z ograniczeniem dostępu ma je napisane - w razie potrzeby mogę je dopisać.
