### PR TITLE
Permission tests unification

### DIFF
--- a/poradnia/stats/mixins.py
+++ b/poradnia/stats/mixins.py
@@ -1,0 +1,92 @@
+from django.core.exceptions import ImproperlyConfigured
+from guardian.shortcuts import assign_perm
+
+from users.factories import UserFactory
+
+
+class PermissionStatusMixin(object):
+    """Mixin to verify object permission status codes for different users
+    Require user with username='john' and password='pass'
+    Attributes:
+        permission (str): Permission name or "superuser"
+        status_anonymous (int): Status code for anonymouser
+        status_has_permission (int): Status code for user with permission
+        status_no_permission (403): Status code for user without permission
+        url (str): url to test
+    NOTE: based on https://github.com/watchdogpolska/feder/blob/master/feder/main/mixins.py#L113
+    """
+    url = None
+    permissions = None
+    status_anonymous = 302
+    status_no_permission = 403
+    status_has_permission = 200
+
+    def setUp(self):
+        super(PermissionStatusMixin, self).setUp()
+
+    def get_url(self):
+        """Get url to tests
+        Returns:
+            str: url to test
+        Raises:
+            ImproperlyConfigured: Missing a url to test
+        """
+        if self.url is None:
+            raise ImproperlyConfigured(
+                '{0} is missing a url to test. Define {0}.url '
+                'or override {0}.get_url().'.format(self.__class__.__name__))
+        return self.url
+
+    def get_permissions(self):
+        """Returns the permission to assign for granted permission user
+        Returns:
+            list: A list of permission in format ```codename.permission_name```
+        Raises:
+            ImproperlyConfigured: Missing a permission to assign
+        """
+        if self.permissions is None:
+            raise ImproperlyConfigured(
+                '{0} is missing a permissions to assign. Define {0}.permission '
+                'or override {0}.get_permission().'.format(self.__class__.__name__))
+        return self.permissions[:]
+
+    def make_regular_user(self):
+        """Returns a user with no extra permissions"""
+        return UserFactory(username="John")
+
+    def make_privileged_user(self):
+        """Returns a user with permissions granted"""
+        permissions = self.get_permissions()
+        if "superuser" in permissions:
+            permissions.pop(permissions.index("superuser"))
+            user = UserFactory(username="John", is_superuser=True)
+        else:
+            user = UserFactory(username="John")
+        for perm in permissions:
+            assign_perm(perm, user)
+        return user
+
+    def login(self, user):
+        """Login client to user"""
+        self.client.login(username=user.username, password='pass')
+
+    def test_status_code_for_anonymous_user(self):
+        """A test status code of response for anonymous user"""
+        response = self.client.get(self.get_url())
+        self.assertEqual(response.status_code, self.status_anonymous)
+    
+    def test_status_code_for_signed_user(self):
+        """A test for status code of response for signed (logged-in) user"""
+        user = self.make_regular_user()
+        self.login(user)
+        response = self.client.get(self.get_url())
+        self.assertEqual(response.status_code, self.status_no_permission)
+
+    def test_status_code_for_privileged_user(self):
+        """A test for status code of response for privileged user
+        Grant permission to permission-carrying object and login before test
+        """
+        user = self.make_privileged_user()
+        self.login(user)
+        response = self.client.get(self.get_url())
+        self.assertEqual(response.status_code, self.status_has_permission)

--- a/poradnia/stats/tests.py
+++ b/poradnia/stats/tests.py
@@ -11,6 +11,7 @@ from django.test import TestCase
 from django.utils.timezone import make_aware
 from letters.factories import LetterFactory
 from letters.models import Letter
+from stats.mixins import PermissionStatusMixin
 from stats.utils import DATE_FORMAT_MONTHLY, DATE_FORMAT_WEEKLY, GapFiller
 from users.factories import UserFactory
 from users.models import User
@@ -31,115 +32,94 @@ def purge_users(func):
     return func_wrapper
 
 
-class StatsCaseCreatedPermissionTestCase(TestCase):
-    def setUp(self):
-        self.api_url = reverse('stats:case_created_api')
-        self.render_url = reverse('stats:case_created_render')
-        self.main_url = reverse('stats:case_created')
-
-    def test_permission_forbidden(self):
-        user = UserFactory(is_superuser=False)
-        self.client.login(username=user.username, password='pass')
-        for url in [self.api_url, self.render_url, self.main_url]:
-            resp = self.client.get(url)
-            self.assertEqual(resp.status_code, 403)
-
-    def test_permission_not_logged_in(self):
-        user = UserFactory(is_superuser=False)
-        for url in [self.api_url, self.render_url, self.main_url]:
-            resp = self.client.get(url)
-            self.assertEqual(resp.status_code, 302)
-
-    @skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
-    def test_permission_superuser(self):
-        user = UserFactory(is_superuser=True)
-        self.client.login(username=user.username, password='pass')
-        for url in [self.api_url, self.render_url, self.main_url]:
-            resp = self.client.get(url)
-            self.assertEqual(resp.status_code, 200)
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsCaseCreatedPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:case_created')
+    permissions = ["superuser"]
 
 
-class StatsCaseUnansweredPermissionTestCase(TestCase):
-    def setUp(self):
-        self.api_url = reverse('stats:case_unanswered_api')
-        self.render_url = reverse('stats:case_unanswered_render')
-        self.main_url = reverse('stats:case_unanswered')
-
-    def test_permission_not_logged_in(self):
-        user = UserFactory(is_superuser=False)
-        self.client.login(username=user.username, password='pass')
-        for url in [self.api_url, self.render_url, self.main_url]:
-            resp = self.client.get(url)
-            self.assertEqual(resp.status_code, 403)
-
-    def test_permission_logged_in(self):
-        user = UserFactory(is_superuser=False)
-        for url in [self.api_url, self.render_url, self.main_url]:
-            resp = self.client.get(url)
-            self.assertEqual(resp.status_code, 302)
-
-    @skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
-    def test_permission_superuser(self):
-        user = UserFactory(is_superuser=True)
-        self.client.login(username=user.username, password='pass')
-        for url in [self.api_url, self.render_url, self.main_url]:
-            resp = self.client.get(url)
-            self.assertEqual(resp.status_code, 200)
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsCaseCreatedRenderPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:case_created_render')
+    permissions = ["superuser"]
 
 
-class StatsCaseReactionPermissionTestCase(TestCase):
-    def setUp(self):
-        self.api_url = reverse('stats:case_reaction_api')
-        self.render_url = reverse('stats:case_reaction_render')
-        self.main_url = reverse('stats:case_reaction')
-
-    def test_permission_not_logged_in(self):
-        user = UserFactory(is_superuser=False)
-        self.client.login(username=user.username, password='pass')
-        for url in [self.api_url, self.render_url, self.main_url]:
-            resp = self.client.get(url)
-            self.assertEqual(resp.status_code, 403)
-
-    def test_permission_logged_in(self):
-        user = UserFactory(is_superuser=False)
-        for url in [self.api_url, self.render_url, self.main_url]:
-            resp = self.client.get(url)
-            self.assertEqual(resp.status_code, 302)
-
-    def test_permission_superuser(self):
-        user = UserFactory(is_superuser=True)
-        self.client.login(username=user.username, password='pass')
-        for url in [self.api_url, self.render_url, self.main_url]:
-            resp = self.client.get(url)
-            self.assertEqual(resp.status_code, 200)
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsCaseCreatedApiPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:case_created_api')
+    permissions = ["superuser"]
 
 
-class StatsUserRegisteredPermissionTestCase(TestCase):
-    def setUp(self):
-        self.api_url = reverse('stats:user_registered_api')
-        self.render_url = reverse('stats:user_registered_render')
-        self.main_url = reverse('stats:user_registered')
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsCaseUnansweredPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:case_unanswered')
+    permissions = ["superuser"]
 
-    def test_permission_forbidden(self):
-        user = UserFactory(is_superuser=False)
-        self.client.login(username=user.username, password='pass')
-        for url in [self.api_url, self.render_url, self.main_url]:
-            resp = self.client.get(url)
-            self.assertEqual(resp.status_code, 403)
 
-    def test_permission_not_logged_in(self):
-        user = UserFactory(is_superuser=False)
-        for url in [self.api_url, self.render_url, self.main_url]:
-            resp = self.client.get(url)
-            self.assertEqual(resp.status_code, 302)
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsCaseUnansweredRenderPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:case_unanswered_render')
+    permissions = ["superuser"]
 
-    @skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
-    def test_permission_superuser(self):
-        user = UserFactory(is_superuser=True)
-        self.client.login(username=user.username, password='pass')
-        for url in [self.api_url, self.render_url, self.main_url]:
-            resp = self.client.get(url)
-            self.assertEqual(resp.status_code, 200)
+
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsCaseUnansweredApiPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:case_unanswered_api')
+    permissions = ["superuser"]
+
+
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsCaseReactionPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:case_reaction')
+    permissions = ["superuser"]
+
+
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsCaseReactionRenderPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:case_reaction_render')
+    permissions = ["superuser"]
+
+
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsCaseReactionApiPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:case_reaction_api')
+    permissions = ["superuser"]
+
+
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsLetterCreatedPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:letter_created')
+    permissions = ["superuser"]
+
+
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsLetterCreatedRenderPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:letter_created_render')
+    permissions = ["superuser"]
+
+
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsLetterCreatedApiPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:letter_created_api')
+    permissions = ["superuser"]
+
+
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsUserRegisteredPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:user_registered')
+    permissions = ["superuser"]
+
+
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsUserRegisteredRenderPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:user_registered_render')
+    permissions = ["superuser"]
+
+
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsUserRegisteredApiPermissionTestCase(PermissionStatusMixin, TestCase):
+    url = reverse('stats:user_registered_api')
+    permissions = ["superuser"]
 
 
 @skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
@@ -392,6 +372,59 @@ class StatsCaseUnansweredApiTestCase(TestCase):
             {'date': "2015-01", 'count': 1},
             {'date': "2015-02", 'count': 0},
             {'date': "2015-03", 'count': 2}
+        ]
+        self.assertEqual(result, expected)
+
+
+@skipUnless(connection.vendor == 'mysql', "MySQL specific tests")
+class StatsLetterCreatedApiTestCase(TestCase):
+    def setUp(self):
+        polyfill_http_response_json()
+        self.url = reverse('stats:letter_created_api')
+        self.staff_user = UserFactory(is_staff=True)
+        self.non_staff_user = UserFactory(is_staff=False)
+
+    def _prepare_letters(self, letter_data):
+        letters = []
+        for created_on, created_by in letter_data:
+            obj = LetterFactory(created_by=created_by)
+            obj.created_on=make_aware(created_on)
+            obj.save()
+            letters.append(obj)
+        return letters
+
+    def test_no_cases(self):
+        user = UserFactory(is_superuser=True)
+        self.client.login(username=user.username, password='pass')
+
+        result = self.client.get(self.url).json()
+        expected = []
+        self.assertEqual(result, expected)
+
+    def test_basic(self):
+        db_data = [
+            (
+                datetime(2015, 1, 2),
+                self.non_staff_user
+            ),
+            (
+                datetime(2015, 1, 2),
+                self.staff_user
+            ),
+            (
+                datetime(2015, 2, 3),
+                self.non_staff_user
+            ),
+        ]
+
+        user = UserFactory(is_superuser=True)
+        self.client.login(username=user.username, password='pass')
+        self._prepare_letters(db_data)
+
+        result = self.client.get(self.url).json()
+        expected = [
+            {'date': "2015-01", 'staff': 1, 'client': 1},
+            {'date': "2015-02", 'staff': 0, 'client': 1},
         ]
         self.assertEqual(result, expected)
 


### PR DESCRIPTION
Dostosowałem zaproponowany mixin w taki sposób, by dodanie testów dla nowych widoków wymagało jak najmniej kodu. Mixin generuje 9 testów: 3 urle x 3 typy użytkownika.

Przy okazji dodałem testy dla `LetterCreated`, bo okazało się, że ich brakuje.