### PR TITLE
pin numpy version

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,4 +51,4 @@ django-braces==1.12.0
 future==0.16
 django-github-revision==0.0.3
 enum34==1.1.6
-numpy==1.14.5
+numpy==1.14.5 # pyup: ignore

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -51,3 +51,4 @@ django-braces==1.12.0
 future==0.16
 django-github-revision==0.0.3
 enum34==1.1.6
+numpy==1.14.5


### PR DESCRIPTION
Po ostatnim deploymencie w mailach (z crona) oraz przy startowaniu aplikacji zaczęły pojawiać się ostrzeżenia postaci:
/home/porady/releases/releases/20180809224655/env/local/lib/python2.7/site-packages/scipy/sparse/lil.py:19: RuntimeWarning: numpy.dtype size changed, may indicate binary incompatibility. Expected 96, got 88
  from . import _csparsetools

Spowodowane jest to tym, że talon wymaga numpy w dowolnej wersji, a wyszła ostatnio wersja 1.15
Ustaliłem wersję <1.15

PS. Tymczasem poprawiłem ręcznie, ale niedługo robię migrację.