### PR TITLE
Fix & add testing for subject outgoing mail 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+TEST=
+
 start:
 	docker-compose up -d
 
@@ -11,7 +13,7 @@ build:
 	docker-compose build web
 
 test:
-	docker-compose run web python manage.py test --keepdb --verbosity=2
+	docker-compose run web python manage.py test --keepdb --verbosity=2 ${TEST}
 
 wait_mysql:
 	docker-compose run web bash -c 'wait-for-it db:3306'

--- a/poradnia/letters/tests/test_views.py
+++ b/poradnia/letters/tests/test_views.py
@@ -144,15 +144,11 @@ class AdminNewCaseTestCase(NewCaseMixin, TestCase):
 
     def test_user_registration(self):
         self.post()
-        self.assertMailSend(
-            template="users/email/new_user.txt", to=self.email
-        )
+        self.assertMailSend(template="users/email/new_user.txt", to=self.email)
 
     def test_user_notification(self):
         self.post()
-        self.assertMailSend(
-            template="cases/email/case_registered.txt", to=self.email
-        )
+        self.assertMailSend(template="cases/email/case_registered.txt", to=self.email)
 
 
 class UserNewCaseTestCase(NewCaseMixin, TestCase):

--- a/poradnia/letters/tests/test_views.py
+++ b/poradnia/letters/tests/test_views.py
@@ -70,15 +70,15 @@ class NewCaseAnonymousTestCase(NewCaseMixin, TestCase):
 
     def test_user_registration(self):
         self.post()
-        self.assertSendTemplates(
-            template_name="users/email/new_user.txt",
+        self.assertMailSend(
+            template="users/email/new_user.txt",
             subject="Rejestracja w Poradni Sieci Obywatelskiej - Watchdog Polska",
         )
 
     def test_user_notification(self):
         self.post()
-        self.assertSendTemplates(
-            template_name="cases/email/case_registered.txt",
+        self.assertMailSend(
+            template="cases/email/case_registered.txt",
             subject="Sprawa  zarejestrowana w systemie",
         )
 
@@ -144,12 +144,15 @@ class AdminNewCaseTestCase(NewCaseMixin, TestCase):
 
     def test_user_registration(self):
         self.post()
-        self.assertSendTemplates("users/email/new_user.txt")
+        self.assertMailSend(
+            template="users/email/new_user.txt", to=self.email
+        )
 
     def test_user_notification(self):
         self.post()
-        self.assertSendTemplates("cases/email/case_registered.txt")
-        self.assertIn(self.email, mail.outbox[1].to)
+        self.assertMailSend(
+            template="cases/email/case_registered.txt", to=self.email
+        )
 
 
 class UserNewCaseTestCase(NewCaseMixin, TestCase):
@@ -183,8 +186,8 @@ class UserNewCaseTestCase(NewCaseMixin, TestCase):
 
     def test_user_self_notify(self):
         self.post()
-        self.assertSendTemplates(
-            template_name="cases/email/case_registered.txt",
+        self.assertMailSend(
+            template="cases/email/case_registered.txt",
             subject="Sprawa  zarejestrowana w systemie",
             to=self.user.email,
         )
@@ -268,9 +271,16 @@ class AddLetterTestCase(CaseMixin, TestCase):
         func()
         self.assertEqual(Letter.objects.get().status, status)
         template = "letters/email/letter_created.txt"
-        emails = [x.to[0] for x in mail.outbox if template in self._templates_used(x)]
-        self.assertEqual(user_user.email in emails, user_notify)
-        self.assertEqual(user_staff.email in emails, staff_notify)
+        self.assertMailSend(
+            template=template,
+            to=user_user.email,
+            expected_count=1 if user_notify else 0,
+        )
+        self.assertMailSend(
+            template=template,
+            to=user_staff.email,
+            expected_count=1 if staff_notify else 0,
+        )
         if settings.RICH_TEXT_ENABLED:
             self.assertIn(
                 '<p><em>bold</em> <strong>italic</strong> <a href="http://google.pl">link</a></p>',
@@ -307,10 +317,7 @@ class AddLetterTestCase(CaseMixin, TestCase):
         data["project"] = "True"
 
         self.client.post(self.url, data=data)
-
-        emails = [x.to[0] for x in mail.outbox]
-
-        self.assertIn(management_user.email, emails)
+        self.assertMailSend(to=management_user.email)
 
     def test_notify_management_if_not_lawyer(self):
         management_user = UserFactory(notify_unassigned_letter=True)
@@ -323,9 +330,7 @@ class AddLetterTestCase(CaseMixin, TestCase):
 
         self.client.post(self.url, data=data)
 
-        emails = [x.to[0] for x in mail.outbox]
-
-        self.assertIn(management_user.email, emails)
+        self.assertMailSend(to=management_user.email)
 
         self.user = UserFactory(is_staff=True)
         assign_perm("can_send_to_client", self.user, self.case)
@@ -344,9 +349,7 @@ class AddLetterTestCase(CaseMixin, TestCase):
 
         self.client.post(self.url, data=data)
 
-        emails = [x.to[0] for x in mail.outbox]
-
-        self.assertNotIn(management_user.email, emails)
+        self.assertMailSend(to=management_user.email, expected_count=0)
 
 
 class ProjectAddLetterTestCase(CaseMixin, TestCase):
@@ -394,10 +397,6 @@ class ProjectAddLetterTestCase(CaseMixin, TestCase):
 class SendLetterTestCase(CaseMixin, TestCase):
     note_text = "Lorem ipsum XYZ123"
 
-    def assertEmailTemplateUsed(self, template):
-        emails = [x.to[0] for x in mail.outbox if template in self._templates_used(x)]
-        return emails
-
     def assertEmailReceived(self, email, template=None):
         emails = [
             x.to[0]
@@ -442,9 +441,9 @@ class SendLetterTestCase(CaseMixin, TestCase):
         assign_perm("can_send_to_client", user1, self.object.case)
         self._test_send()
 
-        emails = self.assertEmailTemplateUsed("letters/email/letter_drop_a_note.txt")
-        self.assertEqual(user1.email in emails, True)
-        self.assertEqual(user2.email in emails, False)
+        template = "letters/email/letter_drop_a_note.txt"
+        self.assertMailSend(template=template, to=user1.email)
+        self.assertMailSend(template=template, to=user2.email, expected_count=0)
 
     def test_notify_user_about_acceptation(self):
         user1 = self._add_random_user(is_staff=True, case=self.object.case)
@@ -452,15 +451,10 @@ class SendLetterTestCase(CaseMixin, TestCase):
 
         self._test_send()
 
-        self.assertEmailTemplateUsed("letters/email/letter_send_to_client.txt")
-        self.assertEmailReceived(user1.email, "letters/email/letter_send_to_client.txt")
-        self.assertEmailReceived(user2.email, "letters/email/letter_send_to_client.txt")
-        recipient_list = [addr for x in mail.outbox for addr in x.to]
-        self.assertEqual(
-            recipient_list.count(user2.email),
-            1,
-            "Sended double notificatiton to client",
-        )
+        template = "letters/email/letter_send_to_client.txt"
+        self.assertMailSend(template=template, to=user1.email)
+        self.assertMailSend(template=template, to=user2.email)
+        self.assertMailSend(to=user2.email)  # avoid double message
 
     def test_accepted_letter_contains_attachment(self):
         letter = AttachmentFactory(letter=self.object)
@@ -482,11 +476,11 @@ class SendLetterTestCase(CaseMixin, TestCase):
         user3 = self._add_random_user(is_staff=True, case=self.object.case)
 
         self._test_send()
-
-        self.assertEmailTemplateUsed("letters/email/letter_drop_a_note.txt")
-        self.assertEmailReceived(user1.email, "letters/email/letter_drop_a_note.txt")
-        self.assertEmailReceived(user2.email, "letters/email/letter_drop_a_note.txt")
-        self.assertEmailReceived(user3.email, "letters/email/letter_drop_a_note.txt")
+        template = "letters/email/letter_drop_a_note.txt"
+        self.assertMailSend(template=template, expected_count=3)
+        self.assertMailSend(template=template, to=user1.email)
+        self.assertMailSend(template=template, to=user2.email)
+        self.assertMailSend(template=template, to=user3.email)
 
     def test_not_notify_management_to_internal_if_lawyer_assigned(self):
         user1 = UserFactory(notify_unassigned_letter=True, is_staff=True)
@@ -496,10 +490,11 @@ class SendLetterTestCase(CaseMixin, TestCase):
 
         self._test_send()
 
-        self.assertEmailTemplateUsed("letters/email/letter_drop_a_note.txt")
-        self.assertEmailNotReceived(user1.email, "letters/email/letter_drop_a_note.txt")
-        self.assertEmailReceived(user2.email, "letters/email/letter_drop_a_note.txt")
-        self.assertEmailReceived(user3.email, "letters/email/letter_drop_a_note.txt")
+        template = "letters/email/letter_drop_a_note.txt"
+        self.assertMailSend(template=template, expected_count=2)
+        self.assertMailSend(template=template, to=user1.email, expected_count=0)
+        self.assertMailSend(template=template, to=user2.email)
+        self.assertMailSend(template=template, to=user3.email)
 
 
 class StreamAttachmentViewTestCase(TestCase):

--- a/poradnia/template_mail/utils.py
+++ b/poradnia/template_mail/utils.py
@@ -117,7 +117,7 @@ class TemplateMailManager:
     def send(cls, template_key, recipient_list, context=None, from_email=None, **kwds):
         template = cls.TEMPLATE_MAP[template_key]
         txt, html = template.render(context or {})
-        subject, txt = txt.split("\n", 1)
+        subject, txt = txt.strip().split("\n", 1)
         from_email = from_email if from_email else settings.DEFAULT_FROM_EMAIL
         headers = {}
         if len(sys.argv) > 1 and sys.argv[1] == "test":

--- a/poradnia/utils/tests/mixins.py
+++ b/poradnia/utils/tests/mixins.py
@@ -1,0 +1,29 @@
+from django.core import mail
+
+
+class AssertSendMailMixin:
+    @staticmethod
+    def _templates_used(email):
+        return [
+            template
+            for template in email.extra_headers["Template"].split("-")
+            if email.extra_headers["Template"] and template != "None"
+        ]
+
+    def assertSendTemplates(
+        self, template_name=None, subject=None, to=None, expected_count=1
+    ):
+        emails = [
+            email
+            for email in mail.outbox
+            if (template_name and template_name in self._templates_used(email))
+            and (not subject or subject in email.subject)
+            and (not to or to in email.to)
+        ]
+        self.assertEqual(
+            len(emails),
+            expected_count,
+            "No mail with template {template_name} and subject {subject} was send to {to}".format(
+                template_name=template_name, subject=subject, to=to
+            ),
+        )

--- a/poradnia/utils/tests/mixins.py
+++ b/poradnia/utils/tests/mixins.py
@@ -10,9 +10,7 @@ class AssertSendMailMixin:
             if email.extra_headers["Template"] and template != "None"
         ]
 
-    def assertMailSend(
-        self, template=None, subject=None, to=None, expected_count=1
-    ):
+    def assertMailSend(self, template=None, subject=None, to=None, expected_count=1):
         emails = [
             email
             for email in mail.outbox

--- a/poradnia/utils/tests/mixins.py
+++ b/poradnia/utils/tests/mixins.py
@@ -10,13 +10,13 @@ class AssertSendMailMixin:
             if email.extra_headers["Template"] and template != "None"
         ]
 
-    def assertSendTemplates(
-        self, template_name=None, subject=None, to=None, expected_count=1
+    def assertMailSend(
+        self, template=None, subject=None, to=None, expected_count=1
     ):
         emails = [
             email
             for email in mail.outbox
-            if (template_name and template_name in self._templates_used(email))
+            if (not template or template in self._templates_used(email))
             and (not subject or subject in email.subject)
             and (not to or to in email.to)
         ]
@@ -24,6 +24,6 @@ class AssertSendMailMixin:
             len(emails),
             expected_count,
             "No mail with template {template_name} and subject {subject} was send to {to}".format(
-                template_name=template_name, subject=subject, to=to
+                template_name=template, subject=subject, to=to
             ),
         )


### PR DESCRIPTION
Close #930 

I have introduced subject email testing in a few cases to make sure the problem doesn't recur (regression).
By the way, I adapted the code to be more generic and introduced a unified way to test whether the message was sent.

@marcin-wicha, could you take a look?