### PR TITLE
Setup cypress

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -11,7 +11,7 @@ from .common import *  # noqa
 
 # DEBUG
 DEBUG = env("DEBUG", default=True)
-TESTING = len(sys.argv) > 1 and sys.argv[1] == "test"
+TESTING = (len(sys.argv) > 1 and sys.argv[1] == "test") or env("TEST", default=False)
 TEMPLATES[0]["OPTIONS"]["debug"] = DEBUG
 # END DEBUG
 

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -12,6 +12,7 @@ services:
       # This should make it a bit less likely for someone to run integration
       # tests on production tables and accidentally drop all data.
       DATABASE_URL: mysql://root:password@db/test_poradnia
+      TEST: 1
 
   tests:
     depends_on:

--- a/tests/README.rst
+++ b/tests/README.rst
@@ -20,6 +20,22 @@ Po każdym wykonaniu, Cypress pozostawia po sobie:
 Przy lokalnym wywołaniu testów poprzez docker-compose, pliki widoczne będą na maszynie użytkownika.
 Pliki te nie są śledzone przez repozytorium.
 
+Interfejs Cypress
+-----------------
+Testy uruchomione wewnątrz kontenera Docker używają uproszczonej przeglądarki Electron, wystarczającej
+do zastosowań CI.
+Możliwe jest także uruchomienie testów bez użycia Dockera, co pozwala na interakcję z interfejsem Cypress::
+
+    $ npm install
+    $ npx cypress open
+
+Praca z interfejsem jest przydatna zwłaszcza przy pisaniu nowych testów i debugowaniu istniejących.
+
+Lokalna instancja Cypress wymaga podania parametru `baseUrl`.
+Dokumentacja dotycząca konfiguracji Cypress dostępna jest tutaj_.
+
+.. _tutaj: https://docs.cypress.io/guides/references/configuration.html
+
 Rozbudowa
 ---------
 Kod jest formatowany z użyciem `<prettier.io>`_.

--- a/tests/cypress.json
+++ b/tests/cypress.json
@@ -1,3 +1,3 @@
 {
-    "baseUrl": "http://web:8000"
+  "baseUrl": "http://web:8000"
 }

--- a/tests/cypress/.gitignore
+++ b/tests/cypress/.gitignore
@@ -1,3 +1,2 @@
-support/
 videos/
 screenshots/

--- a/tests/cypress/fixtures/text_file.txt
+++ b/tests/cypress/fixtures/text_file.txt
@@ -1,0 +1,1 @@
+Text file content.

--- a/tests/cypress/fixtures/text_file.txt
+++ b/tests/cypress/fixtures/text_file.txt
@@ -1,1 +1,0 @@
-Text file content.

--- a/tests/cypress/fixtures/text_file1.txt
+++ b/tests/cypress/fixtures/text_file1.txt
@@ -1,0 +1,1 @@
+text_file1.txt content

--- a/tests/cypress/fixtures/text_file2.txt
+++ b/tests/cypress/fixtures/text_file2.txt
@@ -1,0 +1,1 @@
+text_file2.txt content

--- a/tests/cypress/integration/cases.js
+++ b/tests/cypress/integration/cases.js
@@ -107,9 +107,12 @@ describe("cases", () => {
     // It's discouraged to do it in cypress.
     cy.contains("a", "text_file.txt")
       .invoke("attr", "href")
-      .then((href) => {
-        // TODO: download the file through a task.
-        return expect(href).not.to.be.empty;
-      });
+      .then((href) =>
+        cy
+          .task("fetch:get", Cypress.config("baseUrl") + href)
+          .then((content) => {
+            expect(content).to.contain("Text file content.");
+          })
+      );
   });
 });

--- a/tests/cypress/integration/cases.js
+++ b/tests/cypress/integration/cases.js
@@ -33,12 +33,12 @@ describe("cases", () => {
       cy.get('input[type="file"]')
         .filter(":visible")
         .first()
-        .attachFile("text_file.txt");
+        .attachFile("text_file1.txt");
       cy.contains("input", "Zgłoś").click();
     });
 
     // Filename should be displayed on the attachments list.
-    cy.contains("text_file.txt");
+    cy.contains("text_file1.txt");
 
     // Validate that the case has been registered and is visible.
     cy.contains("Wykaz spraw").click();
@@ -55,13 +55,13 @@ describe("cases", () => {
     // Get the attachment link and try to open it.
     // Downloading the file must be done by a task, rather than by the browser, to avoid crossing the web app's boundary.
     // It's discouraged to do it in cypress.
-    cy.contains("a", "text_file.txt")
+    cy.contains("a", "text_file1.txt")
       .invoke("attr", "href")
       .then((href) =>
         cy
           .task("fetch:get", Cypress.config("baseUrl") + href)
           .then((content) => {
-            expect(content).to.contain("Text file content.");
+            expect(content).to.contain("text_file1.txt content");
           })
       );
 
@@ -69,6 +69,10 @@ describe("cases", () => {
     cy.contains("form", "Przedmiot").within(($form) => {
       cy.get('input[name="name"]').clear().type(`letter-title`);
       cy.get('textarea[name="text"]').clear().type(`letter-content`);
+      cy.get('input[type="file"]')
+        .filter(":visible")
+        .first()
+        .attachFile("text_file2.txt");
       cy.contains("input", "Odpowiedz wszystkim").click();
     });
 
@@ -81,6 +85,16 @@ describe("cases", () => {
     cy.contains("Wykaz spraw").click();
     cy.contains("case-title").click();
 
+    // Fetch the attachment.
     cy.contains("letter-content");
+    cy.contains("a", "text_file2.txt")
+      .invoke("attr", "href")
+      .then((href) =>
+        cy
+          .task("fetch:get", Cypress.config("baseUrl") + href)
+          .then((content) => {
+            expect(content).to.contain("text_file2.txt content");
+          })
+      );
   });
 });

--- a/tests/cypress/integration/cases.js
+++ b/tests/cypress/integration/cases.js
@@ -1,6 +1,8 @@
 const { register, login, logout } = require("../testing/auth");
 const { addSuperUserPrivileges } = require("../testing/management");
 const { submitCaseForm, submitLetterForm } = require("../testing/forms");
+const Case = require("../testing/case");
+const Letter = require("../testing/letter");
 const User = require("../testing/user");
 
 describe("cases", () => {
@@ -13,16 +15,8 @@ describe("cases", () => {
     const userRequester = User.fromId("requester");
     const userStaff = User.fromId("staff");
     // `case` is a reserved keyword.
-    const case_ = {
-      title: "case-title",
-      content: "case-content",
-      attachment: "text_file1.txt",
-    };
-    const letter = {
-      title: "letter-title",
-      content: "letter-content",
-      attachment: "text_file2.txt",
-    };
+    const case_ = { attachment: "text_file1.txt", ...Case.fromId("case") };
+    const letter = { attachment: "text_file2.txt", ...Letter.fromId("letter") };
 
     for (const user of [userRequester, userStaff]) {
       register(cy)(user);

--- a/tests/cypress/integration/cases.js
+++ b/tests/cypress/integration/cases.js
@@ -1,4 +1,5 @@
 const { register, login, logout } = require("../testing/auth");
+const { addSuperUserPrivileges } = require("../testing/management");
 const User = require("../testing/user");
 
 describe("cases", () => {
@@ -17,12 +18,7 @@ describe("cases", () => {
     }
 
     // Adding staff privileges has to be done manually.
-    cy.task(
-      "db:query",
-      `update users_user
-      set is_staff=1, is_superuser=1
-      where username="${userStaff.username}"`
-    );
+    addSuperUserPrivileges(cy)(userStaff);
 
     // Open a case as a non-staff user.
     login(cy)(userRequester);

--- a/tests/cypress/plugins/db.js
+++ b/tests/cypress/plugins/db.js
@@ -57,6 +57,7 @@ const clearTables = (tables) => {
 const clear = () =>
   clearTables([
     "records_record",
+    "letters_attachment",
     "letters_letter",
     "cases_caseuserobjectpermission",
     "cases_case",

--- a/tests/cypress/plugins/fetch.js
+++ b/tests/cypress/plugins/fetch.js
@@ -1,0 +1,4 @@
+const fetch = require("node-fetch");
+
+const get = (url) => fetch(url).then((res) => res.text());
+module.exports = { get };

--- a/tests/cypress/plugins/index.js
+++ b/tests/cypress/plugins/index.js
@@ -1,4 +1,5 @@
 const db = require("./db");
+const fetch = require("./fetch");
 
 module.exports = (on, config) => {
   // Register tasks.
@@ -7,5 +8,6 @@ module.exports = (on, config) => {
   on("task", {
     "db:query": db.query,
     "db:clear": db.clear,
+    "fetch:get": fetch.get,
   });
 };

--- a/tests/cypress/support/commands.js
+++ b/tests/cypress/support/commands.js
@@ -1,0 +1,1 @@
+require("cypress-file-upload");

--- a/tests/cypress/support/index.js
+++ b/tests/cypress/support/index.js
@@ -1,0 +1,1 @@
+require("./commands");

--- a/tests/cypress/testing/case.js
+++ b/tests/cypress/testing/case.js
@@ -1,0 +1,6 @@
+const fromId = (id) => ({
+  title: `${id}-title`,
+  content: `${id}-content`,
+});
+
+module.exports = { fromId };

--- a/tests/cypress/testing/forms.js
+++ b/tests/cypress/testing/forms.js
@@ -1,0 +1,31 @@
+// Function filling forms with provided inputs.
+// Submits the form in the final step.
+//
+// Each function expects to be executed from within a `within` call selecting
+// the correct form.
+
+const submitCaseForm = (cy) => (form, { title, content, attachment }) => {
+  cy.get('input[name="name"]').clear().type(title);
+  cy.get('textarea[name="text"]').clear().type(content);
+  if (attachment !== null) {
+    cy.get('input[type="file"]')
+      .filter(":visible")
+      .first()
+      .attachFile(attachment);
+  }
+  cy.contains("input", "Zgłoś").click();
+};
+
+const submitLetterForm = (cy) => (form, { title, content, attachment }) => {
+  cy.get('input[name="name"]').clear().type(title);
+  cy.get('textarea[name="text"]').clear().type(content);
+  if (attachment !== null) {
+    cy.get('input[type="file"]')
+      .filter(":visible")
+      .first()
+      .attachFile(attachment);
+  }
+  cy.contains("input", "Odpowiedz wszystkim").click();
+};
+
+module.exports = { submitCaseForm, submitLetterForm };

--- a/tests/cypress/testing/forms.js
+++ b/tests/cypress/testing/forms.js
@@ -7,7 +7,7 @@
 const submitCaseForm = (cy) => (form, { title, content, attachment }) => {
   cy.get('input[name="name"]').clear().type(title);
   cy.get('textarea[name="text"]').clear().type(content);
-  if (attachment !== null) {
+  if (attachment) {
     cy.get('input[type="file"]')
       .filter(":visible")
       .first()
@@ -19,7 +19,7 @@ const submitCaseForm = (cy) => (form, { title, content, attachment }) => {
 const submitLetterForm = (cy) => (form, { title, content, attachment }) => {
   cy.get('input[name="name"]').clear().type(title);
   cy.get('textarea[name="text"]').clear().type(content);
-  if (attachment !== null) {
+  if (attachment) {
     cy.get('input[type="file"]')
       .filter(":visible")
       .first()

--- a/tests/cypress/testing/letter.js
+++ b/tests/cypress/testing/letter.js
@@ -1,0 +1,6 @@
+const fromId = (id) => ({
+  title: `${id}-title`,
+  content: `${id}-content`,
+});
+
+module.exports = { fromId };

--- a/tests/cypress/testing/management.js
+++ b/tests/cypress/testing/management.js
@@ -1,0 +1,11 @@
+const addSuperUserPrivileges = (cy) => (user) => {
+  const { username } = user;
+  cy.task(
+    "db:query",
+    `update users_user
+      set is_staff=1, is_superuser=1
+      where username="${username}"`
+  );
+};
+
+module.exports = { addSuperUserPrivileges };

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -1308,6 +1308,12 @@
         "sqlstring": "2.3.1"
       }
     },
+    "node-fetch": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.1.tgz",
+      "integrity": "sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==",
+      "dev": true
+    },
     "npm-run-path": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",

--- a/tests/package-lock.json
+++ b/tests/package-lock.json
@@ -475,6 +475,15 @@
         "yauzl": "^2.10.0"
       }
     },
+    "cypress-file-upload": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/cypress-file-upload/-/cypress-file-upload-4.1.1.tgz",
+      "integrity": "sha512-tX6UhuJ63rNgjdzxglpX+ZYf/bM6PDhFMtt1qCBljLtAgdearqyfD1AHqyh59rOHCjfM+bf6FA3o9b/mdaX6pw==",
+      "dev": true,
+      "requires": {
+        "mime": "^2.4.4"
+      }
+    },
     "dashdash": {
       "version": "1.14.1",
       "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
@@ -1222,6 +1231,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "mime": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.6.tgz",
+      "integrity": "sha512-RZKhC3EmpBchfTGBVb8fb+RL2cWyw/32lshnsETttkBAyAUXSGHxbEJWWRXc751DrIxG1q04b8QwMbAwkRPpUA==",
       "dev": true
     },
     "mime-db": {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,7 +1,8 @@
 {
   "name": "tests",
   "devDependencies": {
-    "mysql": "^2.18.1",
-    "cypress": "^5.5.0"
+    "cypress": "^5.5.0",
+    "cypress-file-upload": "^4.1.1",
+    "mysql": "^2.18.1"
   }
 }

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,4 +1,11 @@
 {
+  "description": "Integration tests for watchdogpolska/poradnia",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/watchdogpolska/poradnia.git",
+    "directory": "tests"
+  },
+  "license": "MIT",
   "name": "tests",
   "devDependencies": {
     "cypress": "^5.5.0",

--- a/tests/package.json
+++ b/tests/package.json
@@ -3,6 +3,7 @@
   "devDependencies": {
     "cypress": "^5.5.0",
     "cypress-file-upload": "^4.1.1",
-    "mysql": "^2.18.1"
+    "mysql": "^2.18.1",
+    "node-fetch": "^2.6.1"
   }
 }


### PR DESCRIPTION
- add attachment handling in case letters:
  - both staff and client can add attachments
  - uploaded attachments can be downloaded by the other party
- case search test
  - through the search modal
  - through the case filter form

Fixes #741 