### PR TITLE
Multichoice autocomplete

### DIFF
--- a/poradnia/advicer/filters.py
+++ b/poradnia/advicer/filters.py
@@ -8,7 +8,33 @@ from teryt_tree.dal_ext.filters import AreaMultipleFilter
 
 from poradnia.users.filters import UserChoiceFilter
 
-from .models import Advice
+from .models import Advice, Area, Issue
+
+
+class AdviceAreaFilter(django_filters.ModelMultipleChoiceFilter):
+    """
+    Filter by specifying a subset of existing `Area`s.
+    """
+
+    def __init__(self, queryset=None, widget=None, *args, **kwargs):
+        queryset = queryset or Area.objects.all()
+        widget = widget or autocomplete.ModelSelect2Multiple(
+            url="advicer:area-autocomplete"
+        )
+        super().__init__(queryset=queryset, widget=widget, *args, **kwargs)
+
+
+class AdviceIssueFilter(django_filters.ModelMultipleChoiceFilter):
+    """
+    Filter by specifying a subset of existing `Issue`s.
+    """
+
+    def __init__(self, queryset=None, widget=None, *args, **kwargs):
+        queryset = queryset or Issue.objects.all()
+        widget = widget or autocomplete.ModelSelect2Multiple(
+            url="advicer:issue-autocomplete"
+        )
+        super().__init__(queryset=queryset, widget=widget, *args, **kwargs)
 
 
 class AdviceFilter(CrispyFilterMixin, django_filters.FilterSet):
@@ -20,6 +46,8 @@ class AdviceFilter(CrispyFilterMixin, django_filters.FilterSet):
         label=_("Community"),
         widget=autocomplete.ModelSelect2Multiple(url="teryt:community-autocomplete"),
     )
+    issues = AdviceIssueFilter()
+    area = AdviceAreaFilter()
 
     class Meta:
         model = Advice

--- a/poradnia/advicer/forms.py
+++ b/poradnia/advicer/forms.py
@@ -64,6 +64,10 @@ class AdviceForm(
         widgets = {
             "jst": autocomplete.ModelSelect2(url="teryt:community-autocomplete"),
             "case": autocomplete.ModelSelect2(url="cases:autocomplete"),
+            "issues": autocomplete.ModelSelect2Multiple(
+                url="advicer:issue-autocomplete"
+            ),
+            "area": autocomplete.ModelSelect2Multiple(url="advicer:area-autocomplete"),
         }
 
 

--- a/poradnia/advicer/urls.py
+++ b/poradnia/advicer/urls.py
@@ -8,6 +8,14 @@ urlpatterns = [
     path("<int:pk>", views.AdviceDetail.as_view(), name="detail"),
     path("<int:pk>/edytuj/", views.AdviceUpdate.as_view(), name="update"),
     path("<int:pk>/usun/", views.AdviceDelete.as_view(), name="delete"),
+    path(
+        "issue-autocomplete/",
+        views.IssueAutocomplete.as_view(),
+        name="issue-autocomplete",
+    ),
+    path(
+        "area-autocomplete/", views.AreaAutocomplete.as_view(), name="area-autocomplete"
+    ),
 ]
 
 app_name = "poradnia.advicer"

--- a/poradnia/advicer/views.py
+++ b/poradnia/advicer/views.py
@@ -7,6 +7,7 @@ from braces.views import (
     StaffuserRequiredMixin,
     UserFormKwargsMixin,
 )
+from dal import autocomplete
 from django.shortcuts import get_object_or_404
 from django.utils.translation import ugettext_lazy as _
 from django.views.generic import CreateView, DetailView, UpdateView
@@ -14,10 +15,11 @@ from django_filters.views import FilterView
 
 from poradnia.cases.models import Case
 from poradnia.users.utils import PermissionMixin
+from poradnia.utils.mixins import ExprAutocompleteMixin
 
 from .filters import AdviceFilter
 from .forms import AdviceForm, AttachmentForm
-from .models import Advice, Attachment
+from .models import Advice, Attachment, Issue, Area
 
 from django.urls import reverse_lazy
 
@@ -118,3 +120,21 @@ class AdviceDelete(
 class AdviceDetail(StaffuserRequiredMixin, PermissionMixin, VisibleMixin, DetailView):
     model = Advice
     raise_exception = True
+
+
+class IssueAutocomplete(
+    StaffuserRequiredMixin, ExprAutocompleteMixin, autocomplete.Select2QuerySetView
+):
+    model = Issue
+    search_expr = [
+        "name__icontains",
+    ]
+
+
+class AreaAutocomplete(
+    StaffuserRequiredMixin, ExprAutocompleteMixin, autocomplete.Select2QuerySetView
+):
+    model = Area
+    search_expr = [
+        "name__icontains",
+    ]

--- a/tests/cypress/integration/advices.js
+++ b/tests/cypress/integration/advices.js
@@ -152,10 +152,13 @@ describe.only("advices", () => {
       .filter(':has(input[value="Filtruj"])')
       .within(($form) => {
         submitAdviceFilterForm(cy)($form, {
-          administrativeDivision: administrativeDivisionUnits[0],
+          administrativeDivisions: [
+            administrativeDivisionUnits[0],
+            administrativeDivisionUnits[1],
+          ],
           subject: "advice", // Non null, but matches all advices.
         });
       });
-    validateContainsOnly([advices[0]]);
+    validateContainsOnly([advices[0], advices[1]]);
   });
 });

--- a/tests/cypress/integration/advices.js
+++ b/tests/cypress/integration/advices.js
@@ -1,0 +1,138 @@
+const { register, login, logout } = require("../testing/auth");
+const {
+  addSuperUserPrivileges,
+  createCourt,
+  createAdministrativeDivisionCategory,
+  createAdministrativeDivisionUnit,
+} = require("../testing/management");
+const {
+  submitAdviceForm,
+  submitCaseForm,
+  submitCourtCaseForm,
+  submitLetterForm,
+  submitEventForm,
+} = require("../testing/forms");
+const Case = require("../testing/case");
+const Letter = require("../testing/letter");
+const User = require("../testing/user");
+const Advice = require("../testing/advice");
+
+describe.only("advices", () => {
+  beforeEach(() => {
+    cy.task("db:clear");
+  });
+
+  it("staff can search for an advice", () => {
+    const datetime = {
+      year: 2020,
+      month: "January",
+      day: 1,
+      hour: 12,
+      minute: 30,
+    };
+
+    // Teryt.
+    const administrativeDivisionCategory = {
+      id: 1,
+      name: "admin-category",
+      level: 3,
+    };
+    const administrativeDivisionUnits = [
+      "adminDivisionA",
+      "adminDivisionB",
+      "adminDivisionC",
+    ].map((name) => ({
+      name,
+      level: 3,
+      category: administrativeDivisionCategory.id,
+    }));
+
+    const user = User.fromId("testUser");
+    register(cy)(user);
+
+    // Test specific db setup.
+    addSuperUserPrivileges(cy)(user);
+    createAdministrativeDivisionCategory(cy)(administrativeDivisionCategory);
+    administrativeDivisionUnits.forEach((adminUnit) => {
+      createAdministrativeDivisionUnit(cy)(adminUnit);
+    });
+
+    // Create a few cases.
+    const cases = ["caseA", "caseB", "caseC"].map(Case.fromId);
+
+    for (const case_ of cases) {
+      cy.contains("Nowa sprawa").click();
+
+      // Fill the case form.
+      cy.contains("form", "Treść").within(($form) => {
+        submitCaseForm(cy)($form, case_);
+      });
+    }
+
+    // Create a few advices.
+    const advices = {
+      A: {
+        case: cases[0],
+        datetime,
+        solved: 1,
+        administrativeDivision: administrativeDivisionUnits[0].name,
+        adviceAuthor: user,
+        ...Advice.fromId("adviceA"),
+      },
+
+      B: {
+        case: cases[1],
+        datetime,
+        solved: 1,
+        administrativeDivision: administrativeDivisionUnits[1].name,
+        adviceAuthor: user,
+        ...Advice.fromId("adviceB"),
+      },
+
+      C: {
+        case: cases[2],
+        datetime,
+        solved: 0,
+        administrativeDivision: administrativeDivisionUnits[2].name,
+        adviceAuthor: user,
+        ...Advice.fromId("adviceC"),
+      },
+    };
+
+    // For each advice, find its related case by title and fill an advice form.
+    for (const advice of Object.values(advices)) {
+      cy.contains("Wyszukaj").click();
+      cy.get('input[type="search"]').clear().type(advice.case.title);
+      cy.contains("a", advice.case.title).click();
+
+      // Add an advice.
+      cy.contains("Utwórz nową porade").click();
+      cy.contains("form", "Dane statystyczne").within(($form) => {
+        submitAdviceForm(cy)($form, advice);
+      });
+    }
+
+    // Search for advices using the rich form with filters.
+    cy.contains("Rejestr porad").click();
+
+    // This function is expected to be executed on the advice form.
+    // For each expected advice, validate that its subject is visible.
+    // For all remaining advices - validate that its subject is not visible.
+    const validateContainsOnly = (expectedAdvices) => {
+      const notExpectedAdvices = Object.values(advices).filter(
+        (advice) => !expectedAdvices.includes(advice)
+      );
+      expectedAdvices.forEach((advice) => cy.contains(advice.subject));
+      notExpectedAdvices.forEach((advice) =>
+        cy.contains(advice.subject).should("not.exist")
+      );
+    };
+
+    // Initially, all advices should be visible.
+    validateContainsOnly([advices["A"], advices["B"], advices["C"]]);
+
+    // Pressing the filter button with default values.
+    cy.contains("Filtruj").click();
+    validateContainsOnly([advices["A"], advices["B"], advices["C"]]);
+  });
+});

--- a/tests/cypress/integration/advices.js
+++ b/tests/cypress/integration/advices.js
@@ -4,6 +4,8 @@ const {
   createCourt,
   createAdministrativeDivisionCategory,
   createAdministrativeDivisionUnit,
+  createAdviceArea,
+  createAdviceIssue,
 } = require("../testing/management");
 const {
   submitAdviceForm,
@@ -44,6 +46,18 @@ describe.only("advices", () => {
       administrativeDivisionCategory
     );
 
+    // Advice metadata.
+    const adviceAreas = [
+      "adviceAreaA",
+      "adviceAreaB",
+      "adviceAreaC",
+    ].map((name) => ({ name }));
+    const adviceIssues = [
+      "adviceIssueA",
+      "adviceIssueB",
+      "adviceIssueC",
+    ].map((name) => ({ name }));
+
     const user = User.fromId("testUser");
     register(cy)(user);
 
@@ -52,6 +66,12 @@ describe.only("advices", () => {
     createAdministrativeDivisionCategory(cy)(administrativeDivisionCategory);
     administrativeDivisionUnits.forEach((adminUnit) => {
       createAdministrativeDivisionUnit(cy)(adminUnit);
+    });
+    adviceAreas.forEach((adviceArea) => {
+      createAdviceArea(cy)(adviceArea);
+    });
+    adviceIssues.forEach((adviceIssue) => {
+      createAdviceIssue(cy)(adviceIssue);
     });
 
     // Create a few cases.
@@ -73,6 +93,8 @@ describe.only("advices", () => {
         datetime,
         solved: 1,
         administrativeDivision: administrativeDivisionUnits[0].name,
+        adviceArea: adviceAreas[0],
+        adviceIssue: adviceIssues[0],
         adviceAuthor: user,
         ...Advice.fromId("adviceA"),
       },
@@ -82,6 +104,8 @@ describe.only("advices", () => {
         datetime,
         solved: 1,
         administrativeDivision: administrativeDivisionUnits[1].name,
+        adviceArea: adviceAreas[1],
+        adviceIssue: adviceIssues[1],
         adviceAuthor: user,
         ...Advice.fromId("adviceB"),
       },
@@ -91,6 +115,8 @@ describe.only("advices", () => {
         datetime,
         solved: 0,
         administrativeDivision: administrativeDivisionUnits[2].name,
+        adviceArea: adviceAreas[2],
+        adviceIssue: adviceIssues[2],
         adviceAuthor: user,
         ...Advice.fromId("adviceC"),
       },
@@ -160,5 +186,16 @@ describe.only("advices", () => {
         });
       });
     validateContainsOnly([advices[0], advices[1]]);
+
+    // Another combination - multiselect by adviceArea and adviceIssue.
+    cy.get("form")
+      .filter(':has(input[value="Filtruj"])')
+      .within(($form) => {
+        submitAdviceFilterForm(cy)($form, {
+          adviceAreas: [adviceAreas[0], adviceAreas[1]],
+          adviceIssues: [adviceIssues[1], adviceIssues[2]],
+        });
+      });
+    validateContainsOnly([advices[1]]);
   });
 });

--- a/tests/cypress/integration/cases.js
+++ b/tests/cypress/integration/cases.js
@@ -16,6 +16,7 @@ const Case = require("../testing/case");
 const Letter = require("../testing/letter");
 const User = require("../testing/user");
 const Advice = require("../testing/advice");
+const AdministrativeDivisionUnit = require("../testing/administrative-division-unit");
 
 describe("cases", () => {
   beforeEach(() => {
@@ -47,11 +48,12 @@ describe("cases", () => {
       name: "admin-category",
       level: 3,
     };
-    const administrativeDivisionUnit = {
-      name: "admin-division",
-      level: 3,
-      category: administrativeDivisionCategory.id,
-    };
+    const [
+      administrativeDivisionUnit,
+    ] = AdministrativeDivisionUnit.batchFromIds(
+      ["admin-division"],
+      administrativeDivisionCategory
+    );
     const advice = {
       datetime,
       solved: 1,
@@ -195,10 +197,13 @@ describe("cases", () => {
       // After clicking, the input field should be focused.
       // Type the user's last name.
       // There should be a suggestion with the user's full name. Pressing Enter should select it.
+      //
+      // Filtering is not immediate, hence `wait`.
+      //
       // NOTE: it may be tempting to make the test case click on a suggestion, instead of using Enter, but the widget
       // attaches the element outside of the selected div. It is possible to do it the other way around, but this
       // solution is simpler.
-      cy.focused().type(user.lastName).type("{enter}");
+      cy.focused().type(user.lastName).wait(500).type("{enter}");
     });
 
     cy.contains("Filtruj").click();

--- a/tests/cypress/plugins/db.js
+++ b/tests/cypress/plugins/db.js
@@ -56,6 +56,8 @@ const clearTables = (tables) => {
 // TODO: consider defining the dependency tree and clearing all tables.
 const clear = () =>
   clearTables([
+    "advicer_advice_area",
+    "advicer_advice_issues",
     "advicer_advice",
     "teryt_tree_jednostkaadministracyjna",
     "teryt_tree_category",

--- a/tests/cypress/testing/administrative-division-unit.js
+++ b/tests/cypress/testing/administrative-division-unit.js
@@ -1,0 +1,13 @@
+// When creating many instances, their `lft` and `rght` fields should not
+// overlap, as long as all items are on the same level.
+// This function takes care of that. It should be called at most once per test.
+const batchFromIds = (ids, category) =>
+  ids.map((id, i) => ({
+    name: id,
+    lft: 2 * i,
+    rght: 2 * i + 1,
+    level: 3,
+    category: category.id,
+  }));
+
+module.exports = { batchFromIds };

--- a/tests/cypress/testing/forms.js
+++ b/tests/cypress/testing/forms.js
@@ -75,8 +75,29 @@ const submitCourtCaseForm = (cy) => (form, { court, signature }) => {
 
 const submitAdviceForm = (cy) => (
   form,
-  { subject, comment, datetime, solved, administrativeDivision, adviceAuthor }
+  {
+    subject,
+    comment,
+    datetime,
+    solved,
+    administrativeDivision,
+    adviceAuthor,
+    adviceIssue,
+    adviceArea,
+  }
 ) => {
+  if (adviceIssue) {
+    cy.contains("div", "Zakresy tematyczne").within(($div) => {
+      cy.get("select").selectContaining(adviceIssue.name);
+    });
+  }
+
+  if (adviceArea) {
+    cy.contains("div", "Problemy z zakresu prawa").within(($div) => {
+      cy.get("select").selectContaining(adviceArea.name);
+    });
+  }
+
   cy.contains("div", "Czy pomogliśmy").within(($div) => {
     cy.get("select").select(solved ? "Tak" : "Nie");
   });
@@ -116,7 +137,14 @@ const submitAdviceForm = (cy) => (
 // filter) for any non-boolean value.
 const submitAdviceFilterForm = (cy) => (
   form,
-  { solved, administrativeDivisions, subject, adviceAuthor }
+  {
+    solved,
+    administrativeDivisions,
+    subject,
+    adviceAuthor,
+    adviceIssues,
+    adviceAreas,
+  }
 ) => {
   // If not true/false, set to a noop filter.
   cy.contains("div", "Czy pomogliśmy").within(($div) => {
@@ -167,7 +195,32 @@ const submitAdviceFilterForm = (cy) => (
     }
   });
 
+  // If falsy, unselect all.
+  cy.contains("div", "Problemy z zakresu prawa").within(($div) => {
+    const selectElement = cy.get("select");
+    if (adviceAreas) {
+      selectElement.select(adviceAreas.map(({ name }) => name));
+    } else {
+      clearSelect(selectElement);
+    }
+  });
+
+  // If falsy, unselect all.
+  cy.contains("div", "Zakresy tematyczne").within(($div) => {
+    const selectElement = cy.get("select");
+    if (adviceIssues) {
+      selectElement.select(adviceIssues.map(({ name }) => name));
+    } else {
+      clearSelect(selectElement);
+    }
+  });
+
   cy.contains("Filtruj").click();
+};
+
+// Credits: https://stackoverflow.com/a/56343368/7742560
+const clearSelect = (selectElement) => {
+  selectElement.invoke("val", "");
 };
 
 module.exports = {

--- a/tests/cypress/testing/forms.js
+++ b/tests/cypress/testing/forms.js
@@ -116,7 +116,7 @@ const submitAdviceForm = (cy) => (
 // filter) for any non-boolean value.
 const submitAdviceFilterForm = (cy) => (
   form,
-  { solved, administrativeDivision, subject, adviceAuthor }
+  { solved, administrativeDivisions, subject, adviceAuthor }
 ) => {
   // If not true/false, set to a noop filter.
   cy.contains("div", "Czy pomogliśmy").within(($div) => {
@@ -127,17 +127,25 @@ const submitAdviceFilterForm = (cy) => (
 
   // If falsy, clear all input.
   cy.contains("div", "Gmina").within(($div) => {
-    // Autocomplete form.
-    // See other autocomplete forms for details.
-    cy.get(".selection").click();
-    if (administrativeDivision) {
-      cy.focused().type(administrativeDivision.name).wait(500).type("{enter}");
+    // Multi-select autocomplete form.
+    // See other autocomplete forms for more info.
+    if (administrativeDivisions) {
+      for (const administrativeDivision of administrativeDivisions) {
+        // Re-select the field on every iteration.
+        // Less fragile than depending on current state.
+        cy.get(".selection")
+          .click()
+          .focused()
+          .type(administrativeDivision.name)
+          .wait(500)
+          .type("{enter}");
+      }
     } else {
       // NOTE: this is a multiselect field.
       // `clear` seems to clean up all selections, but I have a feeling
       // that this approach may be a bit fragile.
       // Revisit if causes problems.
-      cy.focused().clear().type("{esc}");
+      cy.get(".selection").click().focused().clear().type("{esc}");
     }
   });
 

--- a/tests/cypress/testing/management.js
+++ b/tests/cypress/testing/management.js
@@ -50,8 +50,13 @@ const createAdministrativeDivisionCategory = (cy) => (category) => {
   );
 };
 
+// We're manually setting fields that are usually handled by django-mptt.
+// This function should be kept as simple as possible, as long as it serves
+// its purpose.
+// For a flat tree, `lft` and `rght` should not overlap. Please use the helper
+// function in `administrativeDivistionUnit` to create a batch of values.
 const createAdministrativeDivisionUnit = (cy) => (unit) => {
-  const { name, level, category } = unit;
+  const { name, level, category, lft, rght } = unit;
   cy.task(
     "db:query",
     buildInsertQuery("teryt_tree_jednostkaadministracyjna", {
@@ -64,9 +69,9 @@ const createAdministrativeDivisionUnit = (cy) => (unit) => {
       category_id: category,
       updated_on: withExtraQuotes("2010-01-01"),
       active: 1,
-      lft: 0,
-      rght: 2,
-      tree_id: 1,
+      lft,
+      rght,
+      tree_id: 0,
     })
   );
 };

--- a/tests/cypress/testing/management.js
+++ b/tests/cypress/testing/management.js
@@ -57,7 +57,7 @@ const createAdministrativeDivisionUnit = (cy) => (unit) => {
     buildInsertQuery("teryt_tree_jednostkaadministracyjna", {
       // Id has a length limit.
       // If substrings are not unique, DB will reject a transaction.
-      id: withExtraQuotes(name.slice(0, 7)),
+      id: withExtraQuotes(name.slice(-7)),
       name: withExtraQuotes(name),
       slug: withExtraQuotes(name),
       level,

--- a/tests/cypress/testing/management.js
+++ b/tests/cypress/testing/management.js
@@ -76,9 +76,31 @@ const createAdministrativeDivisionUnit = (cy) => (unit) => {
   );
 };
 
+const createAdviceArea = (cy) => (adviceArea) => {
+  const { name } = adviceArea;
+  cy.task(
+    "db:query",
+    buildInsertQuery("advicer_area", {
+      name: withExtraQuotes(name),
+    })
+  );
+};
+
+const createAdviceIssue = (cy) => (adviceIssue) => {
+  const { name } = adviceIssue;
+  cy.task(
+    "db:query",
+    buildInsertQuery("advicer_issue", {
+      name: withExtraQuotes(name),
+    })
+  );
+};
+
 module.exports = {
   addSuperUserPrivileges,
   createCourt,
   createAdministrativeDivisionCategory,
   createAdministrativeDivisionUnit,
+  createAdviceArea,
+  createAdviceIssue,
 };


### PR DESCRIPTION
Multichoice autocomplete dla dwóch dodatkowych pól używanych przy filtrowaniu porad:
- `advicer.Area`
- `advicer.Issue`

Do tej pory używały zwykłego widżetu, uzupełnionego wszystkimi znanymi opcjami z bazy.

Dodano testy:
- testy jednostkowe endpointu autocomplete
- dedykowany test e2e dla formularza wyszukiwania porad

Fixes #971 