### PR TITLE
Pozwolenie prawnikowi wyświetlenie swoich prawników

### DIFF
--- a/poradnia/users/models.py
+++ b/poradnia/users/models.py
@@ -27,7 +27,7 @@ class UserQuerySet(QuerySet):
         if user.has_perm("users.can_view_other"):
             return self
         if user.is_staff:
-            client_qs = CaseModel.objects.for_user(user).all().values('client')
+            client_qs = CaseModel.objects.for_user(user).all().values("client")
             return self.filter(Q(pk=user.pk) | Q(is_staff=True) | Q(pk__in=client_qs))
         return self.filter(Q(pk=user.pk) | Q(is_staff=True))
 

--- a/poradnia/users/tests.py
+++ b/poradnia/users/tests.py
@@ -87,6 +87,30 @@ class UserQuerySetTestCase(TestCase):
         )  # 2 staff with self
         self.assertEqual(User.objects.for_user(u3).registered().count(), 4)  # all
 
+    def test_for_user_manager_with_client_for_staff(self):
+        """
+        Client (User) should be visible to the staff who handles his case
+        """
+        client = UserFactory()
+        actor = UserFactory(is_staff=True)
+        case = CaseFactory(client=client)
+
+        self.assertEqual(User.objects.for_user(actor).filter(pk=client.pk).count(), 0)
+        assign_perm("cases.can_view", actor, case)
+        self.assertEqual(User.objects.for_user(actor).filter(pk=client.pk).count(), 1)
+
+    def test_for_user_manager_with_client_for_user(self):
+        """
+        A user must be a staff to see other users, even if they have access other client cases
+        """
+        client = UserFactory()
+        actor = UserFactory()
+        case = CaseFactory(client=client)
+
+        self.assertEqual(User.objects.for_user(actor).filter(pk=client.pk).count(), 0)
+        assign_perm("cases.can_view", actor, case)
+        self.assertEqual(User.objects.for_user(actor).filter(pk=client.pk).count(), 0)
+
     def test_with_case_count(self):
         user = UserFactory()
         CaseFactory.create_batch(size=25, client=user)


### PR DESCRIPTION
Zamówiono #1037 gdzie wskazano na:

> widoczność (wybór) innych osób niż członkowie zespołu (trzeba widzieć, aby móc kogoś zaznaczyć jako opcja wyboru), co jest obecnie ograniczone poprzez globalne uprawnienie users.can_view_other.

Zostało zmieniono, aby:

- klient - widział siebie i członków zespołu
- prawnik (członek zespołu) - widział siebie, członków zespołu, a także – co jest efektywnym rozszerzeniem – klientów spraw do których ma dostęp,
- uprzywilejowany operator (osoba z uprawnieniami `users.can_view_other`) widziała wszystkich

Prawnik uzyskuje możliwość m. in. wyświetlenia listy wszystkich swoich klientów (w tym globalnych statystyk każdego z klienta na temat liczby spraw itd.), wyświetlenia jego profilu, a także filtrowania według spraw do których sam ma dostęp 

Uprzejmie proszę o opinie.