### PR TITLE
Add link to delete case

### DIFF
--- a/poradnia/cases/templates/cases/case_detail.html
+++ b/poradnia/cases/templates/cases/case_detail.html
@@ -47,6 +47,10 @@
                         <a class="btn btn-primary" href="{{ object.get_close_url }}"><i
                                 class="fa fa-close"></i> {% trans 'Close' %}</a>
                     {% endif %}
+                    {% if 'delete_case' in case_perms and user.is_staff %}
+                        <a class="btn btn-primary" href="{% url 'admin:cases_case_delete' object_id=object.pk %}"><i
+                                class="fa fa-trash"></i> {% trans 'Delete' %}</a>
+                    {% endif %}
                 </div>
                 <h1 class="case-header-title{% if user.is_staff and object.handled %} success{% endif %}">{{ object.name }}
                     <span class="case-header-number">#{{ object.pk }}</span></h1>


### PR DESCRIPTION
@AgnieszkaZdanowicz wczytując się w Twój ból w #1028 dodałem link:

![obraz](https://user-images.githubusercontent.com/3618479/146663784-a48ccef2-90f9-4dd6-a857-5adc4eaddd7b.png)

Prowadzi on do już znanego Ci ekranu:

![obraz](https://user-images.githubusercontent.com/3618479/146663794-29928048-f551-4d34-bbb3-6bd9d945f027.png)

Wymagane uprawnienie 'can_delete' w sprawie i status członka zespołu. Potwierdziłem, że żadna grupa uprawnień (z wyjątkiem `admin`) nie zawiera obecnie uprawnienia `can_delete`.