### PR TITLE
Update case status when permission updated

### DIFF
--- a/poradnia/cases/urls.py
+++ b/poradnia/cases/urls.py
@@ -12,7 +12,7 @@ urlpatterns = [
         name="permission_add",
     ),
     path(
-        "sprawa-<int:pk>/uprawnienia-<username>)/",
+        "sprawa-<int:pk>/uprawnienia-<username>/",
         views.UserPermissionUpdateView.as_view(),
         name="permission_update",
     ),

--- a/poradnia/cases/views/permissions.py
+++ b/poradnia/cases/views/permissions.py
@@ -99,6 +99,7 @@ class UserPermissionUpdateView(
 
     def form_valid(self, form):
         form.save_obj_perms()
+        self.case.status_update()
         return super().form_valid(form)
 
     def get_form_valid_message(self):
@@ -129,6 +130,7 @@ class CaseGroupPermissionView(CasePermissionTestMixin, FormValidMessageMixin, Fo
     def form_valid(self, form, *args, **kwargs):
         self.form = form
         form.assign()
+        self.case.status_update()
         return super().form_valid(form=form, *args, **kwargs)
 
     def get_success_url(self):
@@ -161,6 +163,7 @@ class UserPermissionRemoveView(
         CaseUserObjectPermission.objects.filter(
             user=self.user, content_object=self.object
         ).delete()
+        self.object.status_update()
 
     def get_success_message(self):
         return _('Removed all permission of "{user}" in case "{case}"').format(


### PR DESCRIPTION
Partial fix for #1035 

Wprowadziłem zmianę, aby modyfikowanie uprawnień (dodawanie, usuwanie, przypisywanie) uprawnień w każdym przypadku skutecznie aktualizowało stan sprawy, bowiem stwierdziłem w tym zakresie pominięcia. 

Realizuje to wspomiane w zagadnieniu:

> automatyczne aktualizowanie stanu sprawy po odebraniu uprawnień prawnikowi

 