### PR TITLE
Refuse email with mismatch 'To' - see #1067

### DIFF
--- a/poradnia/letters/templates/letters/email/letter_refused.html
+++ b/poradnia/letters/templates/letters/email/letter_refused.html
@@ -1,0 +1,5 @@
+Wiadomość do Poradni została odrzucona
+
+<p>Twoja wiadomość przesłana pod adres do "{to}" o tytule "{subject}" została przez system Poradni odrzucona i nie podlega rozpatrzeniu, gdyż wiadomość nie została zaadresowana do Poradni. W celu przesłania wiadomości do Poradni uprzejmie prosimy o adresowanie korespondencji bezpośredni do Poradni np. z wykorzystaniem pola "Do" (ang. "To") programu pocztowego.</p>
+
+{% include '_email_signature.html' %}

--- a/poradnia/letters/templates/letters/email/letter_refused.txt
+++ b/poradnia/letters/templates/letters/email/letter_refused.txt
@@ -1,0 +1,6 @@
+{% load format_text%}
+Wiadomość do Poradni została odrzucona
+
+Twoja wiadomość przesłana pod adres do "{to}" o tytule "{subject}" została przez system Poradni odrzucona i nie podlega rozpatrzeniu, gdyż wiadomość nie została zaadresowana do Poradni. W celu przesłania wiadomości do Poradni uprzejmie prosimy o adresowanie korespondencji bezpośredni do Poradni np. z wykorzystaniem pola "Do" (ang. "To") programu pocztowego.
+
+{% include '_email_signature.txt' %}

--- a/poradnia/letters/views/cbv.py
+++ b/poradnia/letters/views/cbv.py
@@ -11,6 +11,7 @@ from braces.views import (
 )
 from django.contrib import messages
 from django.contrib.auth import get_user_model
+from django.contrib.sites.models import Site
 from django.core.exceptions import PermissionDenied
 from django.core.files.base import File
 from django.http import HttpResponseBadRequest, HttpResponseRedirect, JsonResponse
@@ -21,6 +22,7 @@ from django_filters.views import FilterView
 
 from poradnia.cases.models import Case
 from poradnia.letters.settings import LETTER_RECEIVE_SECRET
+from poradnia.template_mail.utils import TemplateKey, TemplateMailManager
 from poradnia.users.utils import PermissionMixin
 
 from ..forms import AttachmentForm, LetterForm, NewCaseForm
@@ -130,6 +132,53 @@ class LetterListView(
 class ReceiveEmailView(View):
     required_content_type = "multipart/form-data"
 
+    def is_target_current_site(self, manifest):
+        domain = Site.objects.get_current().domain
+        return any(x.endswith(f"@{domain}") for x in manifest["headers"]["to"])
+
+    def is_autoreply(self, manifest):
+        return "auto_reply_type" in manifest["headers"]
+
+    def create_user(self, manifest):
+        return get_user_model().objects.get_by_email_or_create(
+            manifest["headers"]["from"][0]
+        )
+
+    def create_case(self, manifest, actor):
+        return self.get_case(
+            subject=manifest["headers"]["subject"],
+            addresses=manifest["headers"]["to+"],
+            actor=actor,
+        )
+
+    def refuse_letter(self, manifest):
+        context = {
+            "to": manifest["headers"]["to"],
+            "subject": manifest["headers"]["subject"],
+        }
+        TemplateMailManager.send(
+            TemplateKey.LETTER_REFUSED,
+            recipient_list=manifest["headers"]["from"],
+            context=context,
+        )
+
+    def create_letter(self, request, actor, case, manifest):
+        letter = Letter.objects.create(
+            name=manifest["headers"]["subject"],
+            created_by=actor,
+            created_by_is_staff=actor.is_staff,
+            case=case,
+            genre=Letter.GENRE.mail,
+            status=self.get_letter_status(actor=actor, case=case),
+            text=manifest["text"]["content"],
+            html="",
+            signature=manifest["text"]["quote"],
+            eml=File(self.request.FILES["eml"]),
+        )
+        for attachment in request.FILES.getlist("attachment"):
+            Attachment.objects.create(letter=letter, attachment=File(attachment))
+        return letter
+
     def post(self, request):
         if request.GET.get("secret") != LETTER_RECEIVE_SECRET:
             raise PermissionDenied
@@ -148,29 +197,18 @@ class ReceiveEmailView(View):
             )
         manifest = json.load(request.FILES["manifest"])
 
-        actor = get_user_model().objects.get_by_email_or_create(
-            manifest["headers"]["from"][0]
-        )
-        case = self.get_case(
-            subject=manifest["headers"]["subject"],
-            addresses=manifest["headers"]["to+"],
-            actor=actor,
-        )
-        letter = Letter.objects.create(
-            name=manifest["headers"]["subject"],
-            created_by=actor,
-            created_by_is_staff=actor.is_staff,
-            case=case,
-            genre=Letter.GENRE.mail,
-            status=self.get_letter_status(actor=actor, case=case),
-            text=manifest["text"]["content"],
-            html="",
-            signature=manifest["text"]["quote"],
-            eml=File(self.request.FILES["eml"]),
-        )
-        for attachment in request.FILES.getlist("attachment"):
-            Attachment.objects.create(letter=letter, attachment=File(attachment))
-
+        if not self.is_target_current_site(manifest):
+            if not self.is_autoreply(manifest):
+                self.refuse_letter(manifest)
+                return HttpResponseBadRequest(
+                    "There is no e-mail address for the target system in the recipient field. Notification have been send."
+                )
+            return HttpResponseBadRequest(
+                "There is no e-mail address for the target system in the recipient field. Notification have been skipped."
+            )
+        actor = self.create_user(manifest)
+        case = self.create_case(manifest, actor)
+        letter = self.create_letter(request, actor, case, manifest)
         if case.status == Case.STATUS.closed and letter.status == Letter.STATUS.done:
             case.update_status(reopen=True, save=False)
         case.handled = actor.is_staff is True and letter.status == Letter.STATUS.done

--- a/poradnia/template_mail/utils.py
+++ b/poradnia/template_mail/utils.py
@@ -39,6 +39,7 @@ class TemplateKey(Enum):
     EVENT_REMINDER = auto()
 
     LETTER_ACCEPTED = auto()
+    LETTER_REFUSED = auto()
     LETTER_CREATED = auto()
     LETTER_DROP_A_NOTE = auto()
     LETTER_SEND_TO_CLIENT = auto()
@@ -97,6 +98,9 @@ class TemplateMailManager:
         ),
         TemplateKey.LETTER_ACCEPTED: MailTemplate.from_prefix(
             "letters/email/letter_accepted"
+        ),
+        TemplateKey.LETTER_REFUSED: MailTemplate.from_prefix(
+            "letters/email/letter_refused"
         ),
         TemplateKey.LETTER_CREATED: MailTemplate.from_prefix(
             "letters/email/letter_created"


### PR DESCRIPTION
Wprowadziłem mechanizm o którym mowa w #1067 w celu odrzucania wiadomości, które nie zostały zaadresowane bezpośrednio do Poradni. W takim przypadku wiadomość jest odrzucona (przez jakiś czas jest przechowywana w `ERROR` za sprawą `imap-to-webhook`), a także – jeżeli to nie jest automatyczne powiadomienie np. o urlopie – jest przesyłana do nadawcy powiadomienie.  

Powiadomienie zapewnia przejrzystość procesu, gdyby ktoś np. chciał poinformować nas co wysłał do urzędu umieszczając nas w CC / BCC wiadomości skierowanej do urzędu. Taka wiadomość teraz zostanie odrzucona, a użytkownik otrzyma powiadomienie, aby przesłał ją ponownie, jeżeli rzeczywiści jego intencją jest przesłanie jej do nas.

Temat powiadomienia:

> Wiadomość do Poradni została odrzucona

Treść powiadomienia:

> Twoja wiadomość przesłana pod adres do "{to}" o tytule "{subject}" została przez system Poradni odrzucona i nie podlega rozpatrzeniu, gdyż wiadomość nie została zaadresowana do Poradni. W celu przesłania wiadomości do Poradni uprzejmie prosimy o adresowanie korespondencji bezpośredni do Poradni np. z wykorzystaniem pola "Do" (ang. "To") programu pocztowego.