### PR TITLE
Remove UA

### DIFF
--- a/poradnia/templates/base.html
+++ b/poradnia/templates/base.html
@@ -30,22 +30,7 @@
         <link rel="stylesheet" href="{% static 'css/style.min.css' %}">
     {% endif %}
     {% block extra_css %}{% endblock %}
-    <script>
-        (function (i, s, o, g, r, a, m) {
-            i['GoogleAnalyticsObject'] = r;
-            i[r] = i[r] || function () {
-                (i[r].q = i[r].q || []).push(arguments)
-            }, i[r].l = 1 * new Date();
-            a = s.createElement(o),
-                m = s.getElementsByTagName(o)[0];
-            a.async = 1;
-            a.src = g;
-            m.parentNode.insertBefore(a, m)
-        })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
 
-        ga('create', 'UA-71083051-7', 'auto');
-        ga('send', 'pageview');
-    </script>
 </head>
 
 <body>


### PR DESCRIPTION
Deleted Google Universal Analitics code from head section. We do not need it any longer.