### PR TITLE
Update renovate.json to remove pip automerge rules

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -22,26 +22,6 @@
       "groupName": "non-production-dependencies"
     },
     {
-      "matchManagers": ["pip_requirements"],
-      "matchPackageNames": [
-        "lxml",
-        "mysqlclient",
-        "ipdb",
-        "gevent",
-        "Sphinx",
-        "pytz"
-      ],
-      "automerge": true
-    },
-    {
-      "matchPackageNames": ["caniuse-lite"],
-      "automerge": true,
-      "automergeType": "branch",
-      "minimumReleaseAge": "0",
-      "ignoreTests": true,
-      "requiredStatusChecks": null
-    },
-    {
       "matchPackageNames": ["django"],
       "allowedVersions": "^4.2 || ^5.2"
     },


### PR DESCRIPTION
Removed automerge settings for specific pip packages.