### PR TITLE
Add GitHub Container Registry CI/CD workflows and documentation

### DIFF
--- a/.github/workflows/ghcr_prune.yml
+++ b/.github/workflows/ghcr_prune.yml
@@ -1,0 +1,28 @@
+name: GHCR Prune Old Images
+
+on:
+  schedule:
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+
+jobs:
+  prune-ghcr:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+    steps:
+      - name: Prune old dev images
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: poradnia/web/dev
+          package-type: container
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: false
+
+      - name: Prune old production images
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: poradnia/web/production
+          package-type: container
+          min-versions-to-keep: 10
+          delete-only-untagged-versions: false

--- a/.github/workflows/ghcr_push.yml
+++ b/.github/workflows/ghcr_push.yml
@@ -1,0 +1,55 @@
+name: GHCR Build and Push
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  build-and-push-ghcr:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push dev image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .contrib/docker/Dockerfile.web
+          push: true
+          tags: |
+            ghcr.io/watchdogpolska/poradnia/web/dev:${{ github.sha }}
+            ghcr.io/watchdogpolska/poradnia/web/dev:latest
+
+      - name: Create git copy
+        run: cp -r .git .git_copy
+
+      - name: Build and push production image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: .contrib/docker/Dockerfile.web.production
+          push: true
+          tags: |
+            ghcr.io/watchdogpolska/poradnia/web/production:${{ github.sha }}
+            ghcr.io/watchdogpolska/poradnia/web/production:latest
+
+      - name: Remove git copy
+        run: rm -rf .git_copy

--- a/docs/getting_up.rst
+++ b/docs/getting_up.rst
@@ -24,6 +24,25 @@ Wskazane jest także zaimportowanie danych z rejestru TERC poprzez polecenie::
 
     $ docker-compose run web bash ./.contrib/load_terc.sh
 
+Obrazy Docker w GitHub Container Registry
+------------------------------------------
+
+Obrazy Docker aplikacji są dostępne w GitHub Container Registry (GHCR).
+Są one automatycznie budowane i publikowane po scaleniu zmian do gałęzi ``master``.
+
+Obraz deweloperski::
+
+    docker pull ghcr.io/watchdogpolska/poradnia/web/dev:latest
+    docker pull ghcr.io/watchdogpolska/poradnia/web/dev:<commit_sha>
+
+Obraz produkcyjny::
+
+    docker pull ghcr.io/watchdogpolska/poradnia/web/production:latest
+    docker pull ghcr.io/watchdogpolska/poradnia/web/production:<commit_sha>
+
+Tag ``latest`` wskazuje na najnowszą wersję, natomiast tag z hashem commitu
+(np. ``a1b2c3d4e5f6...``) umożliwia pobranie konkretnej wersji.
+
 Wdrożenie
 ---------
 


### PR DESCRIPTION
## Summary
This PR adds automated Docker image building and publishing to GitHub Container Registry (GHCR), along with image lifecycle management and documentation.

## Key Changes
- **New Workflow: `ghcr_push.yml`** - Automatically builds and pushes Docker images to GHCR on every push to the `master` branch
  - Builds both development and production images using separate Dockerfiles
  - Tags images with both commit SHA and `latest` tag for version tracking
  - Includes QEMU setup for multi-platform builds
  
- **New Workflow: `ghcr_prune.yml`** - Scheduled cleanup of old container images
  - Runs weekly (Sundays at 3 AM UTC) with manual trigger option
  - Maintains the 10 most recent versions of both dev and production images
  - Prevents unbounded growth of container registry storage

- **Updated Documentation** - Added new section in `docs/getting_up.rst`
  - Documents how to pull pre-built images from GHCR
  - Explains the difference between `latest` and commit SHA tags
  - Provides pull commands for both development and production images

## Implementation Details
- Uses GitHub Actions official Docker actions (setup-qemu, setup-buildx, login, build-push)
- Leverages `GITHUB_TOKEN` for secure GHCR authentication
- Includes a workaround for production build by copying `.git` directory to preserve git history during build
- Maintains minimal image retention policy (10 versions) to manage storage costs

https://claude.ai/code/session_011gURR5KLbBeSc6pxE26xDL