### PR TITLE
Migrate donate_popup.js to vanilla JS + CSS transitions

### DIFF
--- a/poradnia/static/js/donate_popup.js
+++ b/poradnia/static/js/donate_popup.js
@@ -1,45 +1,23 @@
-jQuery(function() {
+document.addEventListener('DOMContentLoaded', function () {
     var alreadyDonated = Cookies.get('alreadyDonated');
     var popupShown = Cookies.get('popupShown');
-    // // for debug purposes
-    // if (Cookies.get('popupShown')) {
-    //     Cookies.remove('popupShown');
-    //     Cookies.remove('alreadyDonated');
-    // };
     if (!(alreadyDonated || popupShown)) {
-        // Show the popup if the 'popupShown' or 'alreadyDonated' cookie is not set
-        $('#popup-container').fadeIn();
+        document.getElementById('popup-container').classList.add('show');
     }
 
-    function adjustPopupContainer() {
-        if ($(window).width() < 1000) {
-            $('#popup-container').css({
-                'white-space': 'normal',
-                'overflow': 'auto',
-                'max-height': '90vh',
-                'max-width': '90vw'
-            });
-        } else {
-            $('#popup-container').css('white-space', 'nowrap');
-        }
+    var checkbox = document.getElementById('alreadyDonated');
+    if (checkbox) {
+        checkbox.addEventListener('change', function () {
+            if (this.checked) {
+                Cookies.set('alreadyDonated', 'true', { expires: 60 });
+            } else {
+                Cookies.remove('alreadyDonated');
+            }
+        });
     }
-
-    // Call adjustPopupContainer when the document is ready and when the window is resized
-    adjustPopupContainer();
-    $(window).on('resize', adjustPopupContainer);
-
 });
 
 function closePopup() {
-    $('#popup-container').fadeOut();
-    // Set a cookie to remember that the popup has been shown, expires in 1 day
+    document.getElementById('popup-container').classList.remove('show');
     Cookies.set('popupShown', 'true', { expires: 1 });
 }
-
-document.getElementById('alreadyDonated').addEventListener('change', function() {
-    if (this.checked) {
-        Cookies.set('alreadyDonated', 'true', { expires: 60 }); // expires in 60 days
-    } else {
-        Cookies.remove('alreadyDonated');
-    }
-});

--- a/poradnia/templates/donate_popup.html
+++ b/poradnia/templates/donate_popup.html
@@ -2,7 +2,9 @@
 
 <style>
 #popup-container {
-    display: none;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 400ms ease, visibility 0s linear 400ms;
     position: fixed;
     top: 50%;
     left: 50%;
@@ -18,6 +20,19 @@
     /* align-items: center; */
     /* flex-direction: column; */
     text-align: center;
+}
+#popup-container.show {
+    opacity: 1;
+    visibility: visible;
+    transition: opacity 400ms ease, visibility 0s linear 0s;
+}
+@media (max-width: 999px) {
+    #popup-container {
+        white-space: normal;
+        overflow: auto;
+        max-height: 90vh;
+        max-width: 90vw;
+    }
 }
 #popup-container a {
     color: white;


### PR DESCRIPTION
## Summary
- Removes jQuery from `poradnia/static/js/donate_popup.js` (no more `$`/`fadeIn`/`fadeOut`/resize handler).
- Animation handled via CSS `transition: opacity` toggled by `.show` class on `#popup-container`.
- Responsywność (`white-space`, `max-height/width`) przeniesiona do `@media (max-width: 999px)` w szablonie.

Refs #2135 (część #2134).

## Test plan
- [ ] Wyczyść cookies `popupShown` i `alreadyDonated`, odśwież → popup pojawia się z fade-in.
- [ ] Klik "Zamknij" → popup znika z fade-out, kolejne odświeżenie nie pokazuje go.
- [ ] Zaznacz "Już przekazałem/am" → po odświeżeniu popup nie pojawia się.
- [ ] Szerokość okna < 1000px → popup ma scroll i ograniczone wymiary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)