### PR TITLE
Migrate donate_popup_alternative.js to vanilla JS + CSS transitions

### DIFF
--- a/poradnia/static/js/donate_popup_alternative.js
+++ b/poradnia/static/js/donate_popup_alternative.js
@@ -1,45 +1,23 @@
-jQuery(function() {
+document.addEventListener('DOMContentLoaded', function () {
     var altAlreadyDonated = Cookies.get('altAlreadyDonated');
     var altPopupShown = Cookies.get('altPopupShown');
-    // // for debug purposes
-    // if (Cookies.get('altPopupShown')) {
-    //     Cookies.remove('altPopupShown');
-    //     Cookies.remove('altAlreadyDonated');
-    // };
     if (!(altAlreadyDonated || altPopupShown)) {
-        // Show the popup if the 'altPopupShown' or 'altAlreadyDonated' cookie is not set
-        $('#alt-popup-container').fadeIn();
+        document.getElementById('alt-popup-container').classList.add('show');
     }
 
-    function adjustAltPopupContainer() {
-        if ($(window).width() < 1000) {
-            $('#alt-popup-container').css({
-                'white-space': 'normal',
-                'overflow': 'auto',
-                'max-height': '90vh',
-                'max-width': '90vw'
-            });
-        } else {
-            $('#alt-popup-container').css('white-space', 'nowrap');
-        }
+    var checkbox = document.getElementById('altAlreadyDonated');
+    if (checkbox) {
+        checkbox.addEventListener('change', function () {
+            if (this.checked) {
+                Cookies.set('altAlreadyDonated', 'true', { expires: 30 });
+            } else {
+                Cookies.remove('altAlreadyDonated');
+            }
+        });
     }
-
-    // Call adjustAltPopupContainer when the document is ready and when the window is resized
-    adjustAltPopupContainer();
-    $(window).on('resize', adjustAltPopupContainer);
-
 });
 
 function closeAltPopup() {
-    $('#alt-popup-container').fadeOut();
-    // Set a cookie to remember that the popup has been shown, expires in 1 days (shorter than main popup)
+    document.getElementById('alt-popup-container').classList.remove('show');
     Cookies.set('altPopupShown', 'true', { expires: 1 });
 }
-
-document.getElementById('altAlreadyDonated').addEventListener('change', function() {
-    if (this.checked) {
-        Cookies.set('altAlreadyDonated', 'true', { expires: 30 }); // expires in 30 days (shorter than main popup)
-    } else {
-        Cookies.remove('altAlreadyDonated');
-    }
-});

--- a/poradnia/templates/donate_popup_alternative.html
+++ b/poradnia/templates/donate_popup_alternative.html
@@ -2,7 +2,9 @@
 
 <style>
 #alt-popup-container {
-    display: none;
+    opacity: 0;
+    visibility: hidden;
+    transition: opacity 400ms ease, visibility 0s linear 400ms;
     position: fixed;
     top: 50%;
     left: 50%;
@@ -16,6 +18,19 @@
     white-space: nowrap;
     text-align: center;
     border-radius: 10px;
+}
+#alt-popup-container.show {
+    opacity: 1;
+    visibility: visible;
+    transition: opacity 400ms ease, visibility 0s linear 0s;
+}
+@media (max-width: 999px) {
+    #alt-popup-container {
+        white-space: normal;
+        overflow: auto;
+        max-height: 90vh;
+        max-width: 90vw;
+    }
 }
 #alt-popup-container a {
     color: white;


### PR DESCRIPTION
## Summary
- Replace jQuery in `donate_popup_alternative.js` with vanilla JS (`DOMContentLoaded`, `getElementById`).
- Move `fadeIn/fadeOut` to CSS opacity/visibility transitions toggled via a `.show` class.
- Replace `$(window).on('resize', ...)` responsive logic with a CSS `@media (max-width: 999px)` rule.
- Preserve cookie logic (`altPopupShown`, `altAlreadyDonated`).

Closes #2136. Mirrors approach in #2147.

## Test plan
- [ ] Open site without cookies — alternative popup fades in.
- [ ] Click "Zamknij" — popup fades out, `altPopupShown` cookie set (1 day).
- [ ] Reload — popup hidden.
- [ ] Resize below 1000px — popup wraps/scrolls; above 1000px — `nowrap`.
- [ ] No `$`/`jQuery` references in the file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)