### PR TITLE
Add dev bypasses for Turnstile CAPTCHA and MFA enforcement

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -503,9 +503,17 @@ ROSETTA_EXCLUDED_APPLICATIONS = (
 )
 AZURE_CLIENT_SECRET = env.str("ROSETTA_AZURE_CLIENT_SECRET", "")
 
-# Cludflare turnstile settings
+# Cloudflare Turnstile CAPTCHA settings
 TURNSTILE_SITEKEY = env.str("TURNSTILE_SITE_KEY", "")
 TURNSTILE_SECRET = env.str("TURNSTILE_SECRET_KEY", "")
+# When False, removes the Turnstile CAPTCHA field from NewCaseForm.
+# Set to False in local development to skip CAPTCHA without configuring Turnstile keys.
+TURNSTILE_ENABLE = env.bool("TURNSTILE_ENABLE", True)
+
+# When False, EnforceStaffMfaOnPasswordLoginMiddleware is fully disabled.
+# Set to False in local development to allow staff (including superusers) to log in
+# with password only, without configuring TOTP.
+MFA_ENFORCE_ENABLED = env.bool("MFA_ENFORCE_ENABLED", True)
 
 # Send notifications to case or letter change/addition author
 NOTIFY_AUTHOR = env.bool("NOTIFY_AUTHOR", True)

--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -43,8 +43,6 @@ if "test" not in sys.argv:
     }
     ROSETTA_EXCLUDED_APPLICATIONS += ("debug_toolbar",)
 
-TURNSTILE_ENABLE = env("TURNSTILE_ENABLE", default=True)
-
 MY_INTERNAL_IP = env("MY_INTERNAL_IP", default="")
 INTERNAL_IPS = ("127.0.0.1", "10.0.2.2", MY_INTERNAL_IP)
 

--- a/docs/getting_up.rst
+++ b/docs/getting_up.rst
@@ -66,6 +66,37 @@ Następnie wystarczy standardowe polecenie::
 Po uruchomieniu kontenerów użyj konfiguracji uruchamiania VSCode (``launch.json``),
 aby wystartować i debugować serwer Django wewnątrz kontenera.
 
+Pominięcie zabezpieczeń w środowisku deweloperskim
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Niektóre mechanizmy bezpieczeństwa można wyłączyć lokalnie, aby przyspieszyć pracę deweloperską.
+Służą do tego zmienne środowiskowe w pliku ``.env``.
+
+**Wyłączenie CAPTCHA (Turnstile) w formularzu zgłoszenia:**
+
+Zmienna ``TURNSTILE_ENABLE=False`` powoduje, że pole CAPTCHA jest usuwane z formularza
+``NewCaseForm``, co umożliwia testowanie bez konfigurowania kluczy Turnstile::
+
+    TURNSTILE_ENABLE=False
+
+**Wyłączenie wymuszania MFA dla pracowników:**
+
+Zmienna ``MFA_ENFORCE_ENABLED=False`` wyłącza middleware
+``EnforceStaffMfaOnPasswordLoginMiddleware``, dzięki czemu konta pracowników (w tym
+superużytkownik) mogą logować się hasłem bez konfigurowania TOTP::
+
+    MFA_ENFORCE_ENABLED=False
+
+Obie zmienne można dodać do pliku ``.env`` w katalogu projektu:
+
+.. code-block:: bash
+
+    $ echo "TURNSTILE_ENABLE=False" >> .env
+    $ echo "MFA_ENFORCE_ENABLED=False" >> .env
+
+.. warning::
+   Tych ustawień **nie należy używać w środowisku produkcyjnym**.
+
 Obrazy Docker w GitHub Container Registry
 ------------------------------------------
 

--- a/poradnia/letters/forms.py
+++ b/poradnia/letters/forms.py
@@ -126,6 +126,10 @@ class NewCaseForm(SingleButtonMixin, PartialMixin, GIODOMixin, ModelForm):
             del self.fields["email_registration"]
             self.helper.layout.fields.remove("email_registration")
 
+        if not settings.TURNSTILE_ENABLE:
+            del self.fields["turnstile"]
+            self.helper.layout.fields.remove("turnstile")
+
         if not (self.user.is_anonymous or self._is_super_staff()):
             del self.fields["giodo"]
             self.helper.layout.fields.remove("giodo")

--- a/poradnia/users/middleware.py
+++ b/poradnia/users/middleware.py
@@ -63,6 +63,9 @@ class EnforceStaffMfaOnPasswordLoginMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        if not settings.MFA_ENFORCE_ENABLED:
+            return self.get_response(request)
+
         user = getattr(request, "user", None)
         path = request.path_info
 

--- a/poradnia/users/middleware.py
+++ b/poradnia/users/middleware.py
@@ -62,6 +62,18 @@ class EnforceStaffMfaOnPasswordLoginMiddleware:
     def __init__(self, get_response):
         self.get_response = get_response
 
+    def _is_e2e_bypass(self, request) -> bool:
+        if not getattr(settings, "E2E_MFA_BYPASS_ENABLED", False):
+            return False
+        secret = getattr(settings, "E2E_MFA_BYPASS_SECRET", "")
+        return bool(secret and request.COOKIES.get("e2e_bypass_mfa") == secret)
+
+    def _is_exempt_url_name(self, request) -> bool:
+        try:
+            return resolve(request.path_info).url_name in self.EXEMPT_URL_NAMES
+        except Exception:
+            return False
+
     def __call__(self, request):
         if not settings.MFA_ENFORCE_ENABLED:
             return self.get_response(request)
@@ -88,27 +100,8 @@ class EnforceStaffMfaOnPasswordLoginMiddleware:
         ):
             return self.get_response(request)
 
-        # Debug logging to help troubleshoot any issues with E2E bypass
-        # logger.info(
-        #     "E2E enabled=%s",
-        #     getattr(settings, "E2E_MFA_BYPASS_ENABLED", None),
-        # )
-        # logger.info("E2E secret=%s", getattr(settings, "E2E_MFA_BYPASS_SECRET", None))
-        # logger.info("E2E received cookies=%s", request.COOKIES.get("e2e_bypass_mfa"))
-
-        # E2E tests bypass: if enabled and cookie matches secret, skip MFA enforcement.
-        if getattr(settings, "E2E_MFA_BYPASS_ENABLED", False):
-            secret = getattr(settings, "E2E_MFA_BYPASS_SECRET", "")
-            if secret and request.COOKIES.get("e2e_bypass_mfa") == secret:
-                return self.get_response(request)
-
-        try:
-            match = resolve(request.path_info)
-            if match.url_name in self.EXEMPT_URL_NAMES:
-                return self.get_response(request)
-        except Exception:
-            # If resolve fails for some reason, fall through to enforcement
-            pass
+        if self._is_e2e_bypass(request) or self._is_exempt_url_name(request):
+            return self.get_response(request)
 
         auth_method_types = _get_auth_method_types(request)
 


### PR DESCRIPTION
Stacked on #2171.

Wystartowanie tego projektu wymaga kilku kroków, więc sugeruje to uprościc.

## Summary

- **`TURNSTILE_ENABLE=False`**: removes the Turnstile CAPTCHA field from `NewCaseForm`, allowing local development without configuring Cloudflare Turnstile keys.
- **`MFA_ENFORCE_ENABLED=False`**: fully disables `EnforceStaffMfaOnPasswordLoginMiddleware`, allowing staff and superusers to log in with password only (no TOTP required).
- Both settings are defined in `config/settings/common.py` with `env.bool()` and default to `True` (no behaviour change unless explicitly overridden).
- `docs/getting_up.rst`: new subsection *Pominięcie zabezpieczeń w środowisku deweloperskim* documenting both env vars with `.env` snippets and a production warning.

To enable both bypasses locally:

```bash
echo "TURNSTILE_ENABLE=False" >> .env
echo "MFA_ENFORCE_ENABLED=False" >> .env
```

## Test plan

- [ ] `TURNSTILE_ENABLE=False` — open the new-case form as an anonymous user; Turnstile field should be absent
- [ ] `TURNSTILE_ENABLE=True` (default) — Turnstile field should appear as before
- [ ] `MFA_ENFORCE_ENABLED=False` — log in as a staff user with password only; should reach the app without being redirected to MFA setup
- [ ] `MFA_ENFORCE_ENABLED=True` (default) — staff password login without TOTP should redirect to `mfa_index` as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)