### PR TITLE
Fix invalid From header on staff notification emails (#2177)

### DIFF
--- a/poradnia/users/models.py
+++ b/poradnia/users/models.py
@@ -1,5 +1,6 @@
 import logging
 import re
+from email.utils import formataddr
 
 from allauth.account.models import EmailAddress
 from django.contrib.auth.models import AbstractUser, UserManager
@@ -283,7 +284,7 @@ class User(GuardianUserMixin, AbstractUser):
 
     def _get_email_name(self, actor, from_email):
         if from_email:
-            return "{} <{}>".format(actor, from_email)
+            return formataddr((str(actor), from_email))
         return None
 
     def notify(self, actor, verb, **kwargs):


### PR DESCRIPTION
## Summary

- Fixes #2177 — staff users trigger 500 on any POST that sends a notification email because the `From` header is built as an invalid RFC 5322 hybrid (`a@a.pl (team) <sprawa-3@…>`).
- Switches `User._get_email_name` to `email.utils.formataddr`, which properly quotes display names containing special characters (parentheses, `@`, etc.).
- Resulting header: `"a@a.pl (team)" <sprawa-3@…>` — accepted by `django.core.mail.message.sanitize_address`.

## Stacking

Stacked on top of #2176 (`fix/load-dotenv-in-settings`). #2153 will be retargeted to this branch.

## Test plan

- [ ] As a staff user, POST a new letter (`/listy/`) and verify it returns 302 instead of 500.
- [ ] As a staff user, edit a case (`/sprawy/sprawa-N/edytuj/`) and verify it saves and returns 302.
- [ ] Inspect the sent-email log line — the `from` value should be `"… (team)" <sprawa-N@…>` (with quotes around the display-name).
- [ ] Non-staff user path still works (no `(team)` suffix, display-name unquoted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- `dev` <!-- branch-stack -->
  - \#2176
    - **Fix invalid From header on staff notification emails (#2177)** :point\_left:
      - \#2153
        - \#2180
          - \#2181
            - \#2183
              - \#2184
                - \#2185
