### PR TITLE
ci: add git-town/action to visualize stacked PRs

### DIFF
--- a/.github/workflows/git-town.yml
+++ b/.github/workflows/git-town.yml
@@ -1,0 +1,17 @@
+name: Git Town
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  git-town:
+    name: Display the branch stack
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: git-town/action@v1

--- a/.github/workflows/git-town.yml
+++ b/.github/workflows/git-town.yml
@@ -15,3 +15,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - uses: git-town/action@v1
+        with:
+          perennial-branches: |
+            dev


### PR DESCRIPTION
Stacked on #2153.

## Summary

- Add `.github/workflows/git-town.yml` running [`git-town/action@v1`](https://github.com/git-town/action) on every pull request.
- The action renders the PR stack (parents and children) in the PR description so reviewers can navigate between related stacked PRs.

## Test plan

- [ ] Once this PR opens, verify the Git Town workflow runs green.
- [ ] Verify the stack visualization (with links to #2153 and its base) is injected into this PR's description.
- [ ] Verify #2153's description is updated with a pointer to this PR as a child in the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- `dev` <!-- branch-stack -->
  - \#2176
    - \#2178
      - \#2153
        - **ci: add git-town/action to visualize stacked PRs** :point\_left:
          - \#2181
            - \#2183
              - \#2184
                - \#2185
