### PR TITLE
ci(ghcr): use docker/metadata-action for image tags

### DIFF
--- a/.github/workflows/ghcr_push.yml
+++ b/.github/workflows/ghcr_push.yml
@@ -4,6 +4,15 @@ on:
   push:
     branches:
       - master
+      - dev
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - ".contrib/docker/Dockerfile.web"
+      - ".contrib/docker/Dockerfile.web.production"
+      - ".github/workflows/ghcr_push.yml"
+  workflow_dispatch:
 
 jobs:
   build-and-push-ghcr:
@@ -19,30 +28,57 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Extract metadata for dev image
+        id: meta-dev
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/watchdogpolska/poradnia/web/dev
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
+
       - name: Build and push dev image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: .contrib/docker/Dockerfile.web
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta-dev.outputs.tags }}
+          labels: ${{ steps.meta-dev.outputs.labels }}
+
+      - name: Extract metadata for production image
+        id: meta-prod
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/watchdogpolska/poradnia/web/production
           tags: |
-            ghcr.io/watchdogpolska/poradnia/web/dev:${{ github.sha }}
-            ghcr.io/watchdogpolska/poradnia/web/dev:latest
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha,format=long
+            type=raw,value=latest,enable={{is_default_branch}}
 
       - name: Build and push production image
         uses: docker/build-push-action@v7
         with:
           context: .
           file: .contrib/docker/Dockerfile.web.production
-          push: true
+          push: ${{ github.event_name != 'pull_request' }}
           build-args: |
             GIT_SHA=${{ github.sha }}
-          tags: |
-            ghcr.io/watchdogpolska/poradnia/web/production:${{ github.sha }}
-            ghcr.io/watchdogpolska/poradnia/web/production:latest
+          tags: ${{ steps.meta-prod.outputs.tags }}
+          labels: ${{ steps.meta-prod.outputs.labels }}

--- a/.github/workflows/ghcr_push.yml
+++ b/.github/workflows/ghcr_push.yml
@@ -8,11 +8,6 @@ on:
     tags:
       - "v*"
   pull_request:
-    paths:
-      - ".contrib/docker/Dockerfile.web"
-      - ".contrib/docker/Dockerfile.web.production"
-      - ".github/workflows/ghcr_push.yml"
-  workflow_dispatch:
 
 jobs:
   build-and-push-ghcr:
@@ -28,7 +23,6 @@ jobs:
         uses: docker/setup-buildx-action@v4
 
       - name: Login to GHCR
-        if: github.event_name != 'pull_request'
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -54,7 +48,7 @@ jobs:
         with:
           context: .
           file: .contrib/docker/Dockerfile.web
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           tags: ${{ steps.meta-dev.outputs.tags }}
           labels: ${{ steps.meta-dev.outputs.labels }}
 
@@ -77,7 +71,7 @@ jobs:
         with:
           context: .
           file: .contrib/docker/Dockerfile.web.production
-          push: ${{ github.event_name != 'pull_request' }}
+          push: true
           build-args: |
             GIT_SHA=${{ github.sha }}
           tags: ${{ steps.meta-prod.outputs.tags }}


### PR DESCRIPTION
## Summary

- Switch `ghcr_push.yml` to `docker/metadata-action@v5` for computing image tags (branch, PR, semver, SHA, `latest` on default branch) instead of hardcoded `${{ github.sha }}` / `latest`.
- Trigger on pushes to `master`/`dev`, `v*` tags, and on every pull request. Pull requests also push their images to `ghcr.io` (tagged `pr-<n>` + `sha-<sha>`).
- Still pushes to `ghcr.io/watchdogpolska/poradnia/web/{dev,production}`; the build steps and `GIT_SHA` build-arg are unchanged.

## Test plan

- [ ] Merge to `dev` → workflow run tags `ghcr.io/.../web/{dev,production}:dev` and `:sha-<sha>`.
- [ ] Merge to `master` → `:master`, `:sha-<sha>`, and `:latest`.
- [ ] Push a `v1.2.3` tag → `:1.2.3`, `:1.2`, `:1`, `:sha-<sha>`.
- [ ] Open any PR → `:pr-<n>` and `:sha-<sha>` are pushed to ghcr.io.

* `master` <!-- branch-stack -->
  - \#2392
    - **ci(ghcr): use docker/metadata-action for image tags** :point\_left:
      - \#2192
