### PR TITLE
ci(ghcr): cache docker builds via GHA cache scopes

### DIFF
--- a/.github/workflows/ghcr_push.yml
+++ b/.github/workflows/ghcr_push.yml
@@ -51,6 +51,11 @@ jobs:
           push: true
           tags: ${{ steps.meta-dev.outputs.tags }}
           labels: ${{ steps.meta-dev.outputs.labels }}
+          cache-from: |
+            type=gha,scope=dev-master
+            type=gha,scope=dev-dev
+            ${{ github.event_name == 'pull_request' && format('type=gha,scope=dev-pr-{0}', github.event.pull_request.number) || '' }}
+          cache-to: ${{ github.event_name == 'pull_request' && format('type=gha,mode=max,scope=dev-pr-{0}', github.event.pull_request.number) || ((github.event_name == 'push' && (github.ref_name == 'master' || github.ref_name == 'dev')) && format('type=gha,mode=max,scope=dev-{0}', github.ref_name)) || '' }}
 
       - name: Extract metadata for production image
         id: meta-prod
@@ -76,3 +81,8 @@ jobs:
             GIT_SHA=${{ github.sha }}
           tags: ${{ steps.meta-prod.outputs.tags }}
           labels: ${{ steps.meta-prod.outputs.labels }}
+          cache-from: |
+            type=gha,scope=production-master
+            type=gha,scope=production-dev
+            ${{ github.event_name == 'pull_request' && format('type=gha,scope=production-pr-{0}', github.event.pull_request.number) || '' }}
+          cache-to: ${{ github.event_name == 'pull_request' && format('type=gha,mode=max,scope=production-pr-{0}', github.event.pull_request.number) || ((github.event_name == 'push' && (github.ref_name == 'master' || github.ref_name == 'dev')) && format('type=gha,mode=max,scope=production-{0}', github.ref_name)) || '' }}


### PR DESCRIPTION
Stacked on #2191.

## Summary

- Enable `type=gha` cache on both `dev` and `production` image builds in `ghcr_push.yml`.
- **Populate (cache-to):**
  - push to `master` → `<image>-master`
  - push to `dev` → `<image>-dev`
  - pull request → `<image>-pr-<N>`
  - tag push → no cache-to (read-only)
- **Pull (cache-from):** always `<image>-master` and `<image>-dev`; on pull requests additionally `<image>-pr-<N>` so iterative PR pushes reuse the previous build.
- Scopes are prefixed per image (`dev-…` / `production-…`) so the two builds don't collide in the cache.

## Test plan

- [ ] First PR run: cold cache (no PR scope yet), pulls from master/dev.
- [ ] Second push to the same PR: cache-from hits the `<image>-pr-<N>` scope and skips unchanged layers.
- [ ] Merge to `dev`: populates `<image>-dev`, visible to subsequent PRs.
- [ ] Merge to `master`: populates `<image>-master`.
- [ ] Push a `v*` tag: builds without writing to cache (cache-to is empty).

* `master` <!-- branch-stack -->
  - \#2392
    - \#2191
      - **ci(ghcr): cache docker builds via GHA cache scopes** :point\_left:
