### PR TITLE
v1.8.49 - Update dependency django-tinycontent to v2.1.0

### DIFF
--- a/config/settings/common.py
+++ b/config/settings/common.py
@@ -529,6 +529,18 @@ TINYMCE_DEFAULT_CONFIG = {
     "charmap | removeformat | help",
 }
 
+# Use the TinyMCE rich text editor for tinycontent's admin content field
+# instead of the default plain textarea.
+TINYCONTENT_USE_TINYMCE = True
+
+# Scan templates for {% tinycontent %}/{% tinycontent_simple %} usages and
+# auto-create blank content blocks for names that don't exist yet. Runs
+# after `migrate` (DEBUG=False) or on app startup (DEBUG=True); this is
+# the only way new blocks get created now that manual admin "Add" is
+# disabled. Set explicitly (matches the library default) since our
+# tinycontent_add.html override relies on this running to populate `obj`.
+TINYCONTENT_AUTO_INDEX = True
+
 
 ROSETTA_SHOW_AT_ADMIN_PANEL = True
 

--- a/poradnia/__init__.py
+++ b/poradnia/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "1.8.48.deps"
+__version__ = "1.8.49"
 
 
 # Compatibility to eg. django-rest-framework

--- a/poradnia/templates/tinycontent/tinycontent_add.html
+++ b/poradnia/templates/tinycontent/tinycontent_add.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-{% if perms.tinycontent.add_tinycontent and user.is_content_editor %}
-{% url 'admin:tinycontent_tinycontent_add' as add_url %} {% with name_url=name|urlencode %}
-{% blocktrans %}(No content defined: <a href="{{add_url}}?name={{ name_url }}" title="Add content here">Add some</a>){% endblocktrans %}{%endwith %}
+{% if obj and perms.tinycontent.change_tinycontent and user.is_content_editor %}
+{% url 'admin:tinycontent_tinycontent_change' obj.id as edit_url %}
+{% blocktrans %}(No content defined yet: <a href="{{edit_url}}" title="Edit this content block">Edit</a>){% endblocktrans %}
 {% endif %}

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -50,7 +50,7 @@ django-tinymce==5.0.0
 git+https://github.com/PiotrIw/django-atom.git@master
 
 # django-tinycontent is not supported anymore so watchdog maintained fork is used
-git+https://github.com/watchdogpolska/django-tinycontent.git@v1.0.1
+git+https://github.com/watchdogpolska/django-tinycontent.git@v2.1.0
 icalendar==7.2.2
 html2text==2025.4.15
 pyGravatar==0.0.6


### PR DESCRIPTION
## Summary
- Bump `django-tinycontent` from the watchdog-maintained fork's v1.0.1 to v2.1.0
- v2.x moves content-block creation from manual admin "Add" to automatic template-usage scanning (`TINYCONTENT_AUTO_INDEX`, default on, set explicitly), and adds an optional TinyMCE editor for the content field (`TINYCONTENT_USE_TINYMCE`, enabled since `tinymce` is already used elsewhere in the project)
- Fix `poradnia/templates/tinycontent/tinycontent_add.html`, which linked to the admin "Add" view that v2.x disables entirely; updated to match upstream's new pattern (link to the auto-created block's change view, gated on `change_tinycontent`)
- Bump version to 1.8.49

## Test plan
- [x] `make lint` — passed (black/isort/flake8/django-upgrade/pyupgrade)
- [x] `make migrate` — new tinycontent migrations (0006, 0007) applied cleanly against the dev MySQL db
- [x] Verified via shell that existing `TinyContent` rows kept their content and got titles backfilled, and new blocks referenced in templates but missing from the db were auto-created as inactive placeholders
- [x] Smoke-tested home page rendering (200 OK) with the updated `tinycontent_add.html` override
- [x] `poradnia.users` and `poradnia.letters` test suites (159 tests) — all passing